### PR TITLE
save the token also as aws_security_token for legacy aws tools

### DIFF
--- a/awsconfig.go
+++ b/awsconfig.go
@@ -148,5 +148,10 @@ func saveProfile(filename, profile, id, secret, token string) error {
 		return err
 	}
 
+	_, err = iniProfile.NewKey("aws_security_token", token)
+	if err != nil {
+		return err
+	}
+
 	return config.SaveTo(filename)
 }


### PR DESCRIPTION
As already implemented with the env. variables this change will introduce some backwards compatibility especially with the Ansible dynamic inventory script.