### PR TITLE
ADFS 2.0 (HTTP Auth) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # saml2aws
 
-CLI tool which enables you to login and retrieve [AWS](https://aws.amazon.com/) temporary credentials using SAML with [ADFS 3.x](https://msdn.microsoft.com/en-us/library/bb897402.aspx) or [PingFederate](https://www.pingidentity.com/en/products/pingfederate.html) Identity Providers.
+CLI tool which enables you to login and retrieve [AWS](https://aws.amazon.com/) temporary credentials using SAML with [ADFS](https://msdn.microsoft.com/en-us/library/bb897402.aspx) or [PingFederate](https://www.pingidentity.com/en/products/pingfederate.html) Identity Providers.
 
 This is based on python code from [
 How to Implement a General Solution for Federated API/CLI Access Using SAML 2.0](https://blogs.aws.amazon.com/security/post/TxU0AVUS9J00FP/How-to-Implement-a-General-Solution-for-Federated-API-CLI-Access-Using-SAML-2-0).
@@ -16,7 +16,7 @@ The process goes something like this:
 # Requirements
 
 * Identity Provider
-  * ADFS 3.x
+  * ADFS (2.x or 3.x)
   * PingFederate + PingId
 * AWS SAML Provider configured
 
@@ -47,7 +47,12 @@ Commands:
     Exec the supplied command with env vars from STS token.
 
 ```
-saml2aws will default to using ADFS as the Identity Provider. To use PingFederate change the provider flag to Ping eg `--provider=Ping`
+saml2aws will default to using ADFS 3.x as the Identity Provider. To use another provider, use the `--provider` flag:
+
+| IdP          |                    |
+| ------------ | ------------------ |
+| ADFS 2.x     | `--provider=ADFS2` |
+| PingFederate | `--provider=Ping`  |
 
 # Install
 
@@ -177,6 +182,7 @@ This tool would not be possible without some great opensource libraries.
 * [kingpin](github.com/alecthomas/kingpin) command line flags
 * [aws-sdk-go](github.com/aws/aws-sdk-go) AWS Go SDK
 * [go-ini](https://github.com/go-ini/ini) INI file parser
+* [go-ntlmssp](https://github.com/Azure/go-ntlmssp) NTLM/Negotiate authentication
 
 # License
 

--- a/adfs2.go
+++ b/adfs2.go
@@ -1,0 +1,92 @@
+package saml2aws
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/cookiejar"
+
+	"golang.org/x/net/publicsuffix"
+
+	"github.com/Azure/go-ntlmssp"
+	"github.com/PuerkitoBio/goquery"
+	"github.com/pkg/errors"
+)
+
+type ADFS2Client struct {
+	transport http.RoundTripper
+	jar       http.CookieJar
+}
+
+func NewADFS2Client(skipVerify bool) (*ADFS2Client, error) {
+	transport := &ntlmssp.Negotiator{
+		RoundTripper: &http.Transport{
+			TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify},
+		},
+	}
+
+	jar, err := cookiejar.New(&cookiejar.Options{
+		PublicSuffixList: publicsuffix.List,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return &ADFS2Client{
+		transport: transport,
+		jar:       jar,
+	}, nil
+}
+
+func (ac *ADFS2Client) Authenticate(loginDetails *LoginDetails) (string, error) {
+	var samlAssertion string
+	client := http.Client{
+		Transport: ac.transport,
+		Jar:       ac.jar,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			req.SetBasicAuth(loginDetails.Username, loginDetails.Password)
+			return nil
+		},
+	}
+
+	url := fmt.Sprintf("https://%s/adfs/ls/IdpInitiatedSignOn.aspx?loginToRp=urn:amazon:webservices", loginDetails.Hostname)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return samlAssertion, err
+	}
+	req.SetBasicAuth(loginDetails.Username, loginDetails.Password)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return samlAssertion, errors.Wrap(err, "error retieving login form")
+	}
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return samlAssertion, errors.Wrap(err, "error retieving body")
+	}
+
+	doc, err := goquery.NewDocumentFromReader(bytes.NewBuffer(data))
+	if err != nil {
+		return samlAssertion, errors.Wrap(err, "error parsing document")
+	}
+
+	doc.Find("input").Each(func(i int, s *goquery.Selection) {
+		name, ok := s.Attr("name")
+		if !ok {
+			log.Fatalf("unable to locate IDP authentication form submit URL")
+		}
+		if name == "SAMLResponse" {
+			val, ok := s.Attr("value")
+			if !ok {
+				log.Fatalf("unable to locate saml assertion value")
+			}
+			samlAssertion = val
+		}
+	})
+
+	return samlAssertion, nil
+}

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -14,7 +14,7 @@ var (
 	// /verbose      = kingpin.Flag("verbose", "Verbose mode.").Short('v').Bool()
 	profileName  = app.Flag("profile", "The AWS profile to save the temporary credentials").Short('p').Default("saml").String()
 	skipVerify   = app.Flag("skip-verify", "Skip verification of server certificate.").Short('s').Bool()
-	providerName = app.Flag("provider", "The type of SAML IDP provider.").Short('i').Default("ADFS").Enum("ADFS", "Ping")
+	providerName = app.Flag("provider", "The type of SAML IDP provider.").Short('i').Default("ADFS").Enum("ADFS", "ADFS2", "Ping")
 
 	cmdLogin = app.Command("login", "Login to a SAML 2.0 IDP and convert the SAML assertion to an STS token.")
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,5 +1,5 @@
-hash: 9033c30c7b82285336bf7a0577efa8fe1fb8a928c423a64b7f63c5f0cdb9dbe0
-updated: 2016-11-04T05:08:58.499847182+11:00
+hash: 35b7ea8024a6328b1ba5d2bc4a561765f9deaa2f0fd579d1b0842c7fafed4347
+updated: 2016-12-20T15:05:29.5443453+01:00
 imports:
 - name: github.com/alecthomas/kingpin
   version: d2d8a9115b36a531781f0ed3c57bcba202976150
@@ -36,6 +36,8 @@ imports:
   - private/protocol/rest
   - private/protocol/xml/xmlutil
   - service/sts
+- name: github.com/Azure/go-ntlmssp
+  version: 2d5c7863390875bc4b5f81cdb65422602d15b003
 - name: github.com/beevik/etree
   version: ce53c4ce608a92897d74ff8fd47b5a1131e5606c
 - name: github.com/go-ini/ini
@@ -53,6 +55,7 @@ imports:
 - name: golang.org/x/crypto
   version: aa2481cbfe81d911eb62b642b7a6b5ec58bbea71
   subpackages:
+  - md4
   - ssh/terminal
 - name: golang.org/x/net
   version: cfe3c2a7525b50c3d707256e371c90938cfef98a

--- a/glide.yaml
+++ b/glide.yaml
@@ -17,6 +17,7 @@ import:
   - publicsuffix
 - package: gopkg.in/ini.v1
 - package: github.com/segmentio/go-prompt
+- package: github.com/Azure/go-ntlmssp
 testImport:
 - package: github.com/stretchr/testify
   subpackages:

--- a/saml2aws.go
+++ b/saml2aws.go
@@ -28,6 +28,8 @@ func NewSAMLClient(opts *SAMLOptions) (SAMLClient, error) {
 	switch opts.Provider {
 	case "ADFS":
 		return NewADFSClient(opts.SkipVerify)
+	case "ADFS2":
+		return NewADFS2Client(opts.SkipVerify)
 	case "Ping":
 		return NewPingFedClient(opts.SkipVerify)
 	default:


### PR DESCRIPTION
My understanding is that ADFS 2.0 by default will fall back to HTTP Auth (NTLM/Basic), as opposed to the forms-based authentication used in later versions. That is at least the case on our 2008 R2 installations. [go-ntlmssp](https://github.com/Azure/go-ntlmssp) implements a `RoundTrip` decorator that respects the negotiation scheme used by ADFS 2.0, and implements NTLM authentication. See also: https://aws.amazon.com/blogs/security/how-to-implement-federated-api-and-cli-access-using-saml-2-0-and-ad-fs/.

I've implemented this as a separate "ADFS2" provider. I'm not sure how much sense it makes to merge it with the existing provider.

**TODO:**
- [x] Document usage
