### PR TITLE
Add JumpCloud provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,11 @@ Commands:
 ```
 saml2aws will default to using ADFS 3.x as the Identity Provider. To use another provider, use the `--provider` flag:
 
-| IdP          |                    |
-| ------------ | ------------------ |
-| ADFS 2.x     | `--provider=ADFS2` |
-| PingFederate | `--provider=Ping`  |
+| IdP          |                         |
+| ------------ | ----------------------- |
+| ADFS 2.x     | `--provider=ADFS2`      |
+| PingFederate | `--provider=Ping`       |
+| JumpCloud    | `--provider=JumpCloud`  |
 
 # Install
 

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -14,7 +14,7 @@ var (
 	// /verbose      = kingpin.Flag("verbose", "Verbose mode.").Short('v').Bool()
 	profileName  = app.Flag("profile", "The AWS profile to save the temporary credentials").Short('p').Default("saml").String()
 	skipVerify   = app.Flag("skip-verify", "Skip verification of server certificate.").Short('s').Bool()
-	providerName = app.Flag("provider", "The type of SAML IDP provider.").Short('i').Default("ADFS").Enum("ADFS", "ADFS2", "Ping")
+	providerName = app.Flag("provider", "The type of SAML IDP provider.").Short('i').Default("ADFS").Enum("ADFS", "ADFS2", "Ping", "JumpCloud")
 
 	cmdLogin = app.Command("login", "Login to a SAML 2.0 IDP and convert the SAML assertion to an STS token.")
 

--- a/jumpcloud.go
+++ b/jumpcloud.go
@@ -1,0 +1,141 @@
+package saml2aws
+
+import (
+	"bytes"
+	"crypto/tls"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+	"net/http/cookiejar"
+	"net/url"
+	"strings"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/pkg/errors"
+
+	"golang.org/x/net/publicsuffix"
+)
+
+// JumpCloudClient is a wrapper representing a JumpCloud SAML client
+type JumpCloudClient struct {
+	client *http.Client
+}
+
+// NewJumpCloudClient creates a new JumpCloud client
+func NewJumpCloudClient(skipVerify bool) (*JumpCloudClient, error) {
+	tr := &http.Transport{
+		TLSClientConfig: &tls.Config{InsecureSkipVerify: skipVerify},
+	}
+
+	options := &cookiejar.Options{
+		PublicSuffixList: publicsuffix.List,
+	}
+
+	jar, err := cookiejar.New(options)
+	if err != nil {
+		return nil, err
+	}
+
+	client := &http.Client{Transport: tr, Jar: jar}
+
+	return &JumpCloudClient{
+		client: client,
+	}, nil
+}
+
+// Authenticate logs into JumpCloud and returns a SAML response
+func (jc *JumpCloudClient) Authenticate(loginDetails *LoginDetails) (string, error) {
+	var authSubmitURL string
+	var samlAssertion string
+
+	authForm := url.Values{}
+	jumpCloudURL := fmt.Sprintf("https://%s", loginDetails.Hostname)
+
+	res, err := jc.client.Get(jumpCloudURL)
+	if err != nil {
+		return samlAssertion, errors.Wrap(err, "error retieving form")
+	}
+
+	doc, err := goquery.NewDocumentFromResponse(res)
+	if err != nil {
+		return samlAssertion, errors.Wrap(err, "failed to build document from response")
+	}
+
+	doc.Find("input").Each(func(i int, s *goquery.Selection) {
+		updateJumpCloudForm(authForm, s, loginDetails)
+	})
+
+	doc.Find("form").Each(func(i int, s *goquery.Selection) {
+		action, ok := s.Attr("action")
+		if !ok {
+			return
+		}
+		authSubmitURL = action
+	})
+
+	if authSubmitURL == "" {
+		return samlAssertion, fmt.Errorf("unable to locate IDP authentication form submit URL")
+	}
+
+	authSubmitURL = fmt.Sprintf("https://sso.jumpcloud.com/%s", authSubmitURL)
+
+	req, err := http.NewRequest("POST", authSubmitURL, strings.NewReader(authForm.Encode()))
+	if err != nil {
+		return samlAssertion, errors.Wrap(err, "error building authentication request")
+	}
+
+	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+	res, err = jc.client.Do(req)
+	if err != nil {
+		return samlAssertion, errors.Wrap(err, "error retieving login form")
+	}
+
+	data, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return samlAssertion, errors.Wrap(err, "error retieving body")
+	}
+
+	doc, err = goquery.NewDocumentFromReader(bytes.NewBuffer(data))
+	if err != nil {
+		return samlAssertion, errors.Wrap(err, "error parsing document")
+	}
+
+	doc.Find("input").Each(func(i int, s *goquery.Selection) {
+		name, ok := s.Attr("name")
+		if !ok {
+			log.Fatalf("unable to locate IDP authentication form submit URL")
+		}
+		if name == "SAMLResponse" {
+			val, ok := s.Attr("value")
+			if !ok {
+				log.Fatalf("unable to locate saml assertion value")
+			}
+			samlAssertion = val
+		}
+	})
+
+	return samlAssertion, nil
+}
+
+func updateJumpCloudForm(authForm url.Values, s *goquery.Selection, user *LoginDetails) {
+	name, ok := s.Attr("name")
+	if !ok {
+		return
+	}
+
+	lname := strings.ToLower(name)
+	if strings.Contains(lname, "email") {
+		authForm.Add(name, user.Username)
+	} else if strings.Contains(lname, "password") {
+		authForm.Add(name, user.Password)
+	} else {
+		// pass through any hidden fields
+		val, ok := s.Attr("value")
+		if !ok {
+			return
+		}
+		authForm.Add(name, val)
+	}
+}

--- a/saml2aws.go
+++ b/saml2aws.go
@@ -32,6 +32,8 @@ func NewSAMLClient(opts *SAMLOptions) (SAMLClient, error) {
 		return NewADFS2Client(opts.SkipVerify)
 	case "Ping":
 		return NewPingFedClient(opts.SkipVerify)
+	case "JumpCloud":
+		return NewJumpCloudClient(opts.SkipVerify)
 	default:
 		return nil, fmt.Errorf("Invalid provider: %v", opts.Provider)
 	}


### PR DESCRIPTION
This adds JumpCloud support based on the existing PingFed provider.

The "hostname" is the IdP URL, e.g.: `sso.jumpcloud.com/saml2/some-application`

Considered omitting the `sso.jumpcloud.com/saml2/` and having the hostname property just be the application name. Could also add support for customizing the prompt on a per-provider basis in that case. Didn't want to do that without asking, but I'm happy to -- also happy to just leave as-is.