### PR TITLE
Update appveyor build to 1.7.0

### DIFF
--- a/.appveyor/appveyor.yml
+++ b/.appveyor/appveyor.yml
@@ -1,4 +1,4 @@
-version: 1.0.{build}
+version: 1.7.{build}
 branches:
   only:
   - master
@@ -8,9 +8,9 @@ clone_folder: c:\gopath\src\github.com\versent\saml2aws
 environment:
   GOPATH: c:\gopath
   CHOCOLATEY_APIKEY:
-    secure: mQ9vPmmwP1JqAdf45GK5Npl3iCfeRZPda08C2vQWiMxMfFj5WgNqCYEMZmDPxQRa
+    secure: 3kWTz99Qj+ipyaR73CxcJeGRRbmk84MF2ERDu6MyY10cjHAi6s3AVZ2Ccoa+Ioyt
   appName: saml2aws
-  appVersion: 1.3.2
+  appVersion: 1.7.0
 install:
 - ps: >-
     write-output $env:GOPATH
@@ -41,14 +41,14 @@ artifacts:
 - path: $(appName).zip.sha256
 - path: choco/$(appName).$(appVersion).nupkg
 - path: choco/$(appName).$(appVersion).nupkg.sha256
-deploy:
-- provider: GitHub
-  release: saml2aws-$(appveyor_build_version)
-  auth_token:
-    secure: kxO8LOQfcXH15OdilgteFKRn4Y7vUQND84WaR2fgghgiwTTHPLgKV1j+6o/8Ggjx
-  artifact: saml2aws.zip, saml2aws.zip.sha256, choco/saml2aws.1.3.2.nupkg, choco/saml2aws.1.3.2.nupkg.sha256
-  draft: true
-after_deploy:
+#deploy:
+#- provider: GitHub
+#  release: saml2aws-$(appveyor_build_version)
+#  auth_token:
+#    secure: kxO8LOQfcXH15OdilgteFKRn4Y7vUQND84WaR2fgghgiwTTHPLgKV1j+6o/8Ggjx
+#  artifact: saml2aws.zip, saml2aws.zip.sha256, choco/saml2aws.1.3.2.nupkg, choco/saml2aws.1.3.2.nupkg.sha256
+#  draft: true
+deploy_script:
 - ps: >-
     choco apiKey -k $env:CHOCOLATEY_APIKEY -source https://chocolatey.org/
 

--- a/choco/saml2aws.nuspec
+++ b/choco/saml2aws.nuspec
@@ -4,14 +4,14 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>saml2aws</id>
-    <version>1.3.2</version>
+    <version>1.7.0</version>
     <packageSourceUrl>https://github.com/Versent/saml2aws</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>Versent, https://github.com/Versent</owners>
     <title>saml2aws (Install)</title>
     <authors>Mark Wolfe, https://github.com/wolfeidau</authors>
     <projectUrl>https://github.com/Versent/saml2aws</projectUrl>
-    <licenseUrl>https://github.com/davidobrien1985/saml2aws/blob/master/LICENSE.md</licenseUrl>
+    <licenseUrl>https://github.com/versent/saml2aws/blob/master/LICENSE.md</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>
     <projectSourceUrl>https://github.com/Versent/saml2aws</projectSourceUrl>
     <tags>saml2aws admin aws saml CLI</tags>


### PR DESCRIPTION
Updating appveyor to `1.7.0`
Already built from my repo, will need to switch the appveyor build to this one soon.