### PR TITLE
add desiredRole cli parameter

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ A command line tool to help with SAML access to the AWS token service.
 Flags:
       --help            Show context-sensitive help (also try --help-long and --help-man).
   -p, --profile="saml"  The AWS profile to save the temporary credentials
+  -r, --role=ROLE       The AWS role to assume (optional)
   -s, --skip-verify     Skip verification of server certificate.
   -i, --provider="ADFS" The type of SAML IDP provider.
       --version         Show application version.

--- a/cmd/saml2aws/commands/exec.go
+++ b/cmd/saml2aws/commands/exec.go
@@ -15,7 +15,7 @@ import (
 )
 
 // Exec execute the supplied command after seeding the environment
-func Exec(profile string, providerName string, skipVerify bool, cmdline []string) error {
+func Exec(profile string, desiredRole string, providerName string, skipVerify bool, cmdline []string) error {
 
 	if len(cmdline) < 1 {
 		return fmt.Errorf("Command to execute required.")
@@ -27,7 +27,7 @@ func Exec(profile string, providerName string, skipVerify bool, cmdline []string
 	}
 
 	if !ok {
-		err = Login(profile, providerName, skipVerify)
+		err = Login(profile, desiredRole, providerName, skipVerify)
 	}
 	if err != nil {
 		return errors.Wrap(err, "error logging in")

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -14,6 +14,7 @@ var (
 
 	// /verbose      = kingpin.Flag("verbose", "Verbose mode.").Short('v').Bool()
 	profileName  = app.Flag("profile", "The AWS profile to save the temporary credentials").Short('p').Default("saml").String()
+	desiredRole  = app.Flag("role", "The AWS role to assume (optional)").Short('r').String()
 	skipVerify   = app.Flag("skip-verify", "Skip verification of server certificate.").Short('s').Bool()
 	providerName = app.Flag("provider", "The type of SAML IDP provider.").Short('i').Default("ADFS").Enum("ADFS", "ADFS2", "Ping", "JumpCloud", "Okta", "KeyCloak")
 
@@ -58,9 +59,9 @@ func main() {
 
 	switch command {
 	case cmdLogin.FullCommand():
-		err = commands.Login(*profileName, *providerName, *skipVerify)
+		err = commands.Login(*profileName, *desiredRole, *providerName, *skipVerify)
 	case cmdExec.FullCommand():
-		err = commands.Exec(*profileName, *providerName, *skipVerify, *cmdLine)
+		err = commands.Exec(*profileName, *desiredRole, *providerName, *skipVerify, *cmdLine)
 	}
 
 	if err != nil {


### PR DESCRIPTION
Adds the possibility to specify the desired role as a CLI param.

If only one role is returned it is checked to be the desired role. If a list of roles is returned the desired one is selected.

this implements #28