### PR TITLE
Add support for appveyor using Github release tags.

### DIFF
--- a/.appveyor/appveyor.yml
+++ b/.appveyor/appveyor.yml
@@ -1,8 +1,3 @@
-version: 2.0.1
-branches:
-  only:
-  - master
-skip_non_tags: true
 image: WMF 5
 clone_folder: c:\gopath\src\github.com\versent\saml2aws
 environment:
@@ -10,10 +5,11 @@ environment:
   CHOCOLATEY_APIKEY:
     secure: 3kWTz99Qj+ipyaR73CxcJeGRRbmk84MF2ERDu6MyY10cjHAi6s3AVZ2Ccoa+Ioyt
   appName: saml2aws
-  appVersion: 2.0.1
 install:
 - ps: >-
     write-output $env:GOPATH
+
+    write-output $env:APPVEYOR_REPO_TAG_NAME
 
     write-output $env:GOROOT
 
@@ -39,8 +35,8 @@ test_script:
 artifacts:
 - path: $(appName).zip
 - path: $(appName).zip.sha256
-- path: choco/$(appName).$(appVersion).nupkg
-- path: choco/$(appName).$(appVersion).nupkg.sha256
+- path: choco/$(appName).$(APPVEYOR_REPO_TAG_NAME).nupkg
+- path: choco/$(appName).$(APPVEYOR_REPO_TAG_NAME).nupkg.sha256
 #deploy:
 #- provider: GitHub
 #  release: saml2aws-$(appveyor_build_version)
@@ -52,4 +48,4 @@ deploy_script:
 - ps: >-
     choco apiKey -k $env:CHOCOLATEY_APIKEY -source https://chocolatey.org/
 
-    choco push ./choco/${env:appName}.${env:appVersion}.nupkg
+    choco push ./choco/${env:appName}.${env:APPVEYOR_REPO_TAG_NAME}.nupkg

--- a/choco/saml2aws.nuspec
+++ b/choco/saml2aws.nuspec
@@ -4,7 +4,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2015/06/nuspec.xsd">
   <metadata>
     <id>saml2aws</id>
-    <version>2.0.1</version>
+    <version>$version$</version>
     <packageSourceUrl>https://github.com/Versent/saml2aws</packageSourceUrl>
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>Versent, https://github.com/Versent</owners>

--- a/default.build.ps1
+++ b/default.build.ps1
@@ -7,7 +7,7 @@ task 'Compile Go libraries...' {
   $ErrorActionPreference = 'Continue'
   c:\gopath\bin\glide install 2> $null
   $ErrorActionPreference = 'Stop'
-  go build -o "bin/${env:appName}.exe" -ldflags "-X main.Version=${env:appVersion}" "./cmd/$env:appName"
+  go build -o "bin/${env:appName}.exe" -ldflags "-X main.Version=${env:APPVEYOR_REPO_TAG_NAME}" "./cmd/$env:appName"
 }
 
 task 'Prepare for choco stuff...' {
@@ -19,9 +19,9 @@ task 'Prepare for choco stuff...' {
 
 task 'Pack Choco...' {
   Set-Location choco
-  choco pack "${env:appName}.nuspec"
-  $hash = Get-FileHash "${env:appName}.${env:appVersion}.nupkg"
-  "$($hash.Hash) $(Split-Path $hash.Path -Leaf)" > "${env:appName}.${env:appVersion}.nupkg.sha256"
+  choco pack --version "$env:APPVEYOR_REPO_TAG_NAME" "${env:appName}.nuspec"
+  $hash = Get-FileHash "${env:appName}.${env:APPVEYOR_REPO_TAG_NAME}.nupkg"
+  "$($hash.Hash) $(Split-Path $hash.Path -Leaf)" > "${env:appName}.${env:APPVEYOR_REPO_TAG_NAME}.nupkg.sha256"
 }
 
 task 'Zip for GH release...' {


### PR DESCRIPTION
Appveyor will now build tags from Github and automatically use the version from the tag.