### PR TITLE
Fix: Only build appveyor on tags.

### DIFF
--- a/.appveyor/appveyor.yml
+++ b/.appveyor/appveyor.yml
@@ -1,4 +1,5 @@
 image: WMF 5
+skip_non_tags: true
 clone_folder: c:\gopath\src\github.com\versent\saml2aws
 environment:
   GOPATH: c:\gopath


### PR DESCRIPTION
Sorry, last PR had a bug. I forgot to add the "only build on tags" flag to the appveyor.yaml