### PR TITLE
fix_vip_mfa_win

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,8 @@ compile: deps
 	-osarch="darwin/amd64" \
 	-osarch="linux/i386" \
 	-osarch="linux/amd64" \
+	-osarch="windows/amd64" \
+	-osarch="windows/i386" \
 	-output "build/{{.Dir}}_$(VERSION)_{{.OS}}_{{.Arch}}/$(NAME)" \
 	$(shell ./glide novendor)
 

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -52,7 +52,7 @@ func main() {
 	commonFlags := new(flags.CommonFlags)
 	app.Flag("idp-account", "The name of the configured IDP account").Short('a').Default("default").StringVar(&commonFlags.IdpAccount)
 	app.Flag("idp-provider", "The configured IDP provider").EnumVar(&commonFlags.IdpProvider, "ADFS", "ADFS2", "Ping", "JumpCloud", "Okta", "KeyCloak")
-	app.Flag("mfa", "The name of the mfa").Default("Auto").StringVar(&commonFlags.MFA)
+	app.Flag("mfa", "The name of the mfa").EnumVar(&commonFlags.IdpProvider, "Auto", "VIP")
 	app.Flag("skip-verify", "Skip verification of server certificate.").Short('s').BoolVar(&commonFlags.SkipVerify)
 	app.Flag("url", "The URL of the SAML IDP server used to login.").StringVar(&commonFlags.URL)
 	app.Flag("username", "The username used to login.").Envar("SAML2AWS_USERNAME").StringVar(&commonFlags.Username)

--- a/saml2aws.go
+++ b/saml2aws.go
@@ -48,6 +48,24 @@ func (mfbp ProviderList) Mfas(provider string) []string {
 	return mfas
 }
 
+func (mfbp ProviderList) stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+func invalidMFA(provider string, mfa string) bool {
+	supportedMfas := MFAsByProvider.Mfas(provider)
+	supported := MFAsByProvider.stringInSlice(mfa, supportedMfas)
+	if supported {
+		return false
+	}
+	return true
+}
+
 // SAMLClient client interface
 type SAMLClient interface {
 	Authenticate(loginDetails *creds.LoginDetails) (string, error)
@@ -57,16 +75,34 @@ type SAMLClient interface {
 func NewSAMLClient(idpAccount *cfg.IDPAccount) (SAMLClient, error) {
 	switch idpAccount.Provider {
 	case "ADFS":
+		if invalidMFA(idpAccount.Provider, idpAccount.MFA) {
+			return nil, fmt.Errorf("Invalid MFA type: %v for %v provider", idpAccount.MFA, idpAccount.Provider)
+		}
 		return adfs.New(idpAccount)
 	case "ADFS2":
+		if invalidMFA(idpAccount.Provider, idpAccount.MFA) {
+			return nil, fmt.Errorf("Invalid MFA type: %v for %v provider", idpAccount.MFA, idpAccount.Provider)
+		}
 		return adfs2.New(idpAccount)
 	case "Ping":
+		if invalidMFA(idpAccount.Provider, idpAccount.MFA) {
+			return nil, fmt.Errorf("Invalid MFA type: %v for %v provider", idpAccount.MFA, idpAccount.Provider)
+		}
 		return pingfed.New(idpAccount)
 	case "JumpCloud":
+		if invalidMFA(idpAccount.Provider, idpAccount.MFA) {
+			return nil, fmt.Errorf("Invalid MFA type: %v for %v provider", idpAccount.MFA, idpAccount.Provider)
+		}
 		return jumpcloud.New(idpAccount)
 	case "Okta":
+		if invalidMFA(idpAccount.Provider, idpAccount.MFA) {
+			return nil, fmt.Errorf("Invalid MFA type: %v for %v provider", idpAccount.MFA, idpAccount.Provider)
+		}
 		return okta.New(idpAccount)
 	case "KeyCloak":
+		if invalidMFA(idpAccount.Provider, idpAccount.MFA) {
+			return nil, fmt.Errorf("Invalid MFA type: %v for %v provider", idpAccount.MFA, idpAccount.Provider)
+		}
 		return keycloak.New(idpAccount)
 	default:
 		return nil, fmt.Errorf("Invalid provider: %v", idpAccount.Provider)


### PR DESCRIPTION
 - re-enable windows builds
 - remove the default cli option for mfa=auto. If not specifying `--mfa=VIP` on the CLI, it would always default to `Auto` irrespective of what was in `.saml2aws` config
 - put in some validation for provider/mfa combinations

Should resolve issue #114 and #115 
