### PR TITLE
Fix a copy and paste error preventing the exec command from passing in profile/password

### DIFF
--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -75,8 +75,8 @@ func main() {
 	cmdExec := app.Command("exec", "Exec the supplied command with env vars from STS token.")
 	execFlags := new(flags.LoginExecFlags)
 	execFlags.CommonFlags = commonFlags
-	cmdExec.Flag("password", "The password used to login.").Envar("SAML2AWS_PASSWORD").StringVar(&loginFlags.Password)
-	cmdExec.Flag("profile", "The AWS profile to save the temporary credentials").Short('p').Default("saml").StringVar(&loginFlags.Profile)
+	cmdExec.Flag("password", "The password used to login.").Envar("SAML2AWS_PASSWORD").StringVar(&execFlags.Password)
+	cmdExec.Flag("profile", "The AWS profile to save the temporary credentials").Short('p').Default("saml").StringVar(&execFlags.Profile)
 	cmdLine := buildCmdList(cmdExec.Arg("command", "The command to execute."))
 
 	// Trigger the parsing of the command line inputs via kingpin


### PR DESCRIPTION
I updated to latest version of saml2aws (v2.1.0) from v1 and was unable to use the exec subcommand. It is passing a blank string for profile, so I kept getting a security token is invalid error. 

```
InvalidClientTokenId: The security token included in the request is invalid.
	status code: 403, request id: 90676c51-fd74-11e7-83f3-5d8ecdd37c03
error validating token
github.com/versent/saml2aws/cmd/saml2aws/commands.Exec
	/Users/dan/golang/src/github.com/versent/saml2aws/cmd/saml2aws/commands/exec.go:40
main.main
	/Users/dan/golang/src/github.com/versent/saml2aws/cmd/saml2aws/main.go:102
runtime.main
	/usr/local/Cellar/go/1.9.1/libexec/src/runtime/proc.go:185
runtime.goexit
	/usr/local/Cellar/go/1.9.1/libexec/src/runtime/asm_amd64.s:2337
```