### PR TITLE
Add list command to list role ARNs

### DIFF
--- a/cmd/saml2aws/commands/list.go
+++ b/cmd/saml2aws/commands/list.go
@@ -1,0 +1,107 @@
+package commands
+
+import (
+	"encoding/base64"
+	"fmt"
+	"os"
+
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+	"github.com/versent/saml2aws"
+	"github.com/versent/saml2aws/helper/credentials"
+	"github.com/versent/saml2aws/pkg/flags"
+)
+
+// List will list available role ARNs
+func List(loginFlags *flags.LoginExecFlags) error {
+
+	logger := logrus.WithField("command", "list")
+
+	account, err := buildIdpAccount(loginFlags)
+	if err != nil {
+		return errors.Wrap(err, "error building login details")
+	}
+
+	loginDetails, err := resolveLoginDetails(account, loginFlags)
+	if err != nil {
+		fmt.Printf("%+v\n", err)
+		os.Exit(1)
+	}
+
+	fmt.Printf("Authenticating as %s ...\n", account.Username)
+
+	err = loginDetails.Validate()
+	if err != nil {
+		return errors.Wrap(err, "error validating login details")
+	}
+
+	logger.WithField("idpAccount", account).Debug("building provider")
+
+	provider, err := saml2aws.NewSAMLClient(account)
+	if err != nil {
+		return errors.Wrap(err, "error building IdP client")
+	}
+
+	samlAssertion, err := provider.Authenticate(loginDetails)
+	if err != nil {
+		return errors.Wrap(err, "error authenticating to IdP")
+
+	}
+
+	if samlAssertion == "" {
+		fmt.Println("Response did not contain a valid SAML assertion")
+		fmt.Println("Please check your username and password is correct")
+		os.Exit(1)
+	}
+
+	err = credentials.SaveCredentials(loginDetails.URL, loginDetails.Username, loginDetails.Password)
+	if err != nil {
+		return errors.Wrap(err, "error storing password in keychain")
+	}
+
+	data, err := base64.StdEncoding.DecodeString(samlAssertion)
+	if err != nil {
+		return errors.Wrap(err, "error decoding saml assertion")
+	}
+
+	roles, err := saml2aws.ExtractAwsRoles(data)
+	if err != nil {
+		return errors.Wrap(err, "error parsing aws roles")
+	}
+
+	if len(roles) == 0 {
+		fmt.Println("No roles to assume")
+		os.Exit(1)
+	}
+
+	awsRoles, err := saml2aws.ParseAWSRoles(roles)
+	if err != nil {
+		return errors.Wrap(err, "error parsing aws roles")
+	}
+
+	if err := listRoles(awsRoles, samlAssertion, loginFlags); err != nil {
+		return errors.Wrap(err, "Failed to list roles")
+	}
+
+	return nil
+}
+
+func listRoles(awsRoles []*saml2aws.AWSRole, samlAssertion string, loginFlags *flags.LoginExecFlags) error {
+	awsAccounts, err := saml2aws.ParseAWSAccounts(samlAssertion)
+	if err != nil {
+		errors.Wrap(err, "error parsing aws role accounts")
+	}
+
+	saml2aws.AssignPrincipals(awsRoles, awsAccounts)
+
+	fmt.Println("")
+	for _, account := range awsAccounts {
+		fmt.Println(account.Name)
+		for _, role := range account.Roles {
+			fmt.Println(role.RoleARN)
+		}
+		fmt.Println("")
+	}
+
+	return nil
+}

--- a/cmd/saml2aws/commands/list_roles.go
+++ b/cmd/saml2aws/commands/list_roles.go
@@ -13,7 +13,7 @@ import (
 )
 
 // List will list available role ARNs
-func List(loginFlags *flags.LoginExecFlags) error {
+func ListRoles(loginFlags *flags.LoginExecFlags) error {
 
 	logger := logrus.WithField("command", "list")
 

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -80,10 +80,10 @@ func main() {
 	cmdLine := buildCmdList(cmdExec.Arg("command", "The command to execute."))
 
 	// `list` command and settings
-	cmdList := app.Command("list", "List available role ARNs.")
-	listFlags := new(flags.LoginExecFlags)
-	listFlags.CommonFlags = commonFlags
-	cmdList.Flag("password", "The password used to login.").Envar("SAML2AWS_PASSWORD").StringVar(&execFlags.Password)
+	cmdListRoles := app.Command("list-roles", "List available role ARNs.")
+	listRolesFlags := new(flags.LoginExecFlags)
+	listRolesFlags.CommonFlags = commonFlags
+	cmdListRoles.Flag("password", "The password used to login.").Envar("SAML2AWS_PASSWORD").StringVar(&execFlags.Password)
 
 	// Trigger the parsing of the command line inputs via kingpin
 	command := kingpin.MustParse(app.Parse(os.Args[1:]))
@@ -106,8 +106,8 @@ func main() {
 		err = commands.Login(loginFlags)
 	case cmdExec.FullCommand():
 		err = commands.Exec(execFlags, *cmdLine)
-	case cmdList.FullCommand():
-		err = commands.List(listFlags)
+	case cmdListRoles.FullCommand():
+		err = commands.ListRoles(listRolesFlags)
 	case cmdConfigure.FullCommand():
 		err = commands.Configure(configFlags)
 	}

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -79,6 +79,12 @@ func main() {
 	cmdExec.Flag("profile", "The AWS profile to save the temporary credentials").Short('p').Default("saml").StringVar(&execFlags.Profile)
 	cmdLine := buildCmdList(cmdExec.Arg("command", "The command to execute."))
 
+	// `list` command and settings
+	cmdList := app.Command("list", "List available role ARNs.")
+	listFlags := new(flags.LoginExecFlags)
+	listFlags.CommonFlags = commonFlags
+	cmdList.Flag("password", "The password used to login.").Envar("SAML2AWS_PASSWORD").StringVar(&execFlags.Password)
+
 	// Trigger the parsing of the command line inputs via kingpin
 	command := kingpin.MustParse(app.Parse(os.Args[1:]))
 
@@ -100,6 +106,8 @@ func main() {
 		err = commands.Login(loginFlags)
 	case cmdExec.FullCommand():
 		err = commands.Exec(execFlags, *cmdLine)
+	case cmdList.FullCommand():
+		err = commands.List(listFlags)
 	case cmdConfigure.FullCommand():
 		err = commands.Configure(configFlags)
 	}


### PR DESCRIPTION
This commit adds a command to list available role ARNs for the authenticated user.  This is helpful to allow the user to list their roles and then they can use the `--role` command line argument to automate exec calls without having to consult the AWS console.