### PR TITLE
Store password when using the configure command

### DIFF
--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -153,8 +153,8 @@ func resolveLoginDetails(account *cfg.IDPAccount, loginFlags *flags.LoginExecFla
 	}
 
 	// if you supply a password in a flag it takes precedence
-	if loginFlags.Password != "" {
-		loginDetails.Password = loginFlags.Password
+	if loginFlags.CommonFlags.Password != "" {
+		loginDetails.Password = loginFlags.CommonFlags.Password
 	}
 
 	// fmt.Printf("loginDetails %+v\n", loginDetails)

--- a/cmd/saml2aws/commands/login_test.go
+++ b/cmd/saml2aws/commands/login_test.go
@@ -12,8 +12,8 @@ import (
 
 func TestResolveLoginDetailsWithFlags(t *testing.T) {
 
-	commonFlags := &flags.CommonFlags{URL: "https://id.example.com", Username: "wolfeidau", SkipPrompt: true}
-	loginFlags := &flags.LoginExecFlags{CommonFlags: commonFlags, Password: "testtestlol"}
+	commonFlags := &flags.CommonFlags{URL: "https://id.example.com", Username: "wolfeidau", Password: "testtestlol", SkipPrompt: true}
+	loginFlags := &flags.LoginExecFlags{CommonFlags: commonFlags}
 
 	idpa := &cfg.IDPAccount{
 		URL:      "https://id.example.com",

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -56,6 +56,7 @@ func main() {
 	app.Flag("skip-verify", "Skip verification of server certificate.").Short('s').BoolVar(&commonFlags.SkipVerify)
 	app.Flag("url", "The URL of the SAML IDP server used to login.").StringVar(&commonFlags.URL)
 	app.Flag("username", "The username used to login.").Envar("SAML2AWS_USERNAME").StringVar(&commonFlags.Username)
+	app.Flag("password", "The password used to login.").Envar("SAML2AWS_PASSWORD").StringVar(&commonFlags.Password)
 	app.Flag("role", "The ARN of the role to assume.").StringVar(&commonFlags.RoleArn)
 	app.Flag("aws-urn", "The URN used by SAML when you login.").StringVar(&commonFlags.AmazonWebservicesURN)
 	app.Flag("skip-prompt", "Skip prompting for parameters during login.").BoolVar(&commonFlags.SkipPrompt)
@@ -68,14 +69,12 @@ func main() {
 	cmdLogin := app.Command("login", "Login to a SAML 2.0 IDP and convert the SAML assertion to an STS token.")
 	loginFlags := new(flags.LoginExecFlags)
 	loginFlags.CommonFlags = commonFlags
-	cmdLogin.Flag("password", "The password used to login.").Envar("SAML2AWS_PASSWORD").StringVar(&loginFlags.Password)
 	cmdLogin.Flag("profile", "The AWS profile to save the temporary credentials").Short('p').Default("saml").StringVar(&loginFlags.Profile)
 
 	// `exec` command and settings
 	cmdExec := app.Command("exec", "Exec the supplied command with env vars from STS token.")
 	execFlags := new(flags.LoginExecFlags)
 	execFlags.CommonFlags = commonFlags
-	cmdExec.Flag("password", "The password used to login.").Envar("SAML2AWS_PASSWORD").StringVar(&execFlags.Password)
 	cmdExec.Flag("profile", "The AWS profile to save the temporary credentials").Short('p').Default("saml").StringVar(&execFlags.Profile)
 	cmdLine := buildCmdList(cmdExec.Arg("command", "The command to execute."))
 
@@ -83,7 +82,6 @@ func main() {
 	cmdListRoles := app.Command("list-roles", "List available role ARNs.")
 	listRolesFlags := new(flags.LoginExecFlags)
 	listRolesFlags.CommonFlags = commonFlags
-	cmdListRoles.Flag("password", "The password used to login.").Envar("SAML2AWS_PASSWORD").StringVar(&listRolesFlags.Password)
 
 	// Trigger the parsing of the command line inputs via kingpin
 	command := kingpin.MustParse(app.Parse(os.Args[1:]))

--- a/helper/credentials/credentials.go
+++ b/helper/credentials/credentials.go
@@ -35,6 +35,8 @@ type Helper interface {
 	Get(serverURL string) (string, string, error)
 	// List returns the stored serverURLs and their associated usernames.
 	List() (map[string]string, error)
+	// SupportsCredentialStorage returns true or false if there is credential storage.
+	SupportsCredentialStorage() bool
 }
 
 // IsErrCredentialsNotFound returns true if the error
@@ -59,4 +61,8 @@ func (defaultHelper) Get(serverURL string) (string, string, error) {
 
 func (defaultHelper) List() (map[string]string, error) {
 	return map[string]string{}, nil
+}
+
+func (defaultHelper) SupportsCredentialStorage() bool {
+	return false
 }

--- a/helper/credentials/saml.go
+++ b/helper/credentials/saml.go
@@ -31,3 +31,8 @@ func SaveCredentials(url, username, password string) error {
 
 	return CurrentHelper.Add(creds)
 }
+
+// SupportsStorage will return true or false if storage is supported.
+func SupportsStorage() bool {
+	return CurrentHelper.SupportsCredentialStorage()
+}

--- a/helper/osxkeychain/osxkeychain_darwin.go
+++ b/helper/osxkeychain/osxkeychain_darwin.go
@@ -168,6 +168,11 @@ func (h Osxkeychain) List() (map[string]string, error) {
 	return resp, nil
 }
 
+// SupportsCredentialsStorage returns true since storage is supported
+func (Osxkeychain) SupportsCredentialStorage() bool {
+	return true
+}
+
 func splitServer(serverURL string) (*C.struct_Server, error) {
 	u, err := url.Parse(serverURL)
 	if err != nil {

--- a/helper/wincred/wincred_windows.go
+++ b/helper/wincred/wincred_windows.go
@@ -94,3 +94,8 @@ func (h Wincred) List() (map[string]string, error) {
 
 	return resp, nil
 }
+
+// SupportsCredentialsStorage returns true since storage is supported
+func (Wincred) SupportsCredentialStorage() bool {
+	return true
+}

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -9,6 +9,7 @@ type CommonFlags struct {
 	MFA                  string
 	URL                  string
 	Username             string
+	Password             string
 	RoleArn              string
 	AmazonWebservicesURN string
 	SkipPrompt           bool
@@ -24,7 +25,6 @@ func (cf *CommonFlags) RoleSupplied() bool {
 type LoginExecFlags struct {
 	CommonFlags *CommonFlags
 	Profile     string
-	Password    string
 }
 
 // ApplyFlagOverrides overrides IDPAccount with command line settings


### PR DESCRIPTION
This commit adds a password prompt to the `saml2aws configure` command.  This allows users to store their credentials during configure instead of having to store them the first time they run `login` or `exec`.  This seems to work better for my use case since `exec` calls will be automated and I don't want the user to be prompted at that time.

The user is also asked to confirm their password to ensure it is correct before storing while avoiding authentication.

The password flag has been moved into the common flags struct since it is now used by all commands.