### PR TITLE
feat(Login) Support sessions up to 12 hours :tada:

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -10,8 +10,8 @@
 [[projects]]
   name = "github.com/PuerkitoBio/goquery"
   packages = ["."]
-  revision = "09540e565986583836b5fc792fe951ec5fd201dd"
-  version = "v1.3.0"
+  revision = "a86ea073017a6beddef78c8659e7224e8ca634b0"
+  version = "v1.4.0"
 
 [[projects]]
   name = "github.com/alecthomas/kingpin"
@@ -223,6 +223,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "8e5ad434dff4da641ffdfd4d83073bdac313a6290f29590e4ce41e0061778c89"
+  inputs-digest = "5afb5282cc1ca7766bbcc444da86352197566db3115a712277cde0db5102180b"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -31,7 +31,7 @@
 
 [[constraint]]
   name = "github.com/PuerkitoBio/goquery"
-  version = "1.3.0"
+  version = "1.4.0"
 
 [[constraint]]
   name = "github.com/alecthomas/kingpin"

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The process goes something like this:
 * Log in to Identity Provider using form based authentication
 * Build a SAML assertion containing AWS roles
 * Exchange the role and SAML assertion with [AWS STS service](https://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html) to get a temporary set of credentials
-* Save these creds to an aws profile named "saml"
+* Save these credentials to an aws profile named "saml"
 
 # Requirements
 
@@ -27,7 +27,7 @@ The process goes something like this:
 
 Aside from Okta, most of the providers in this project are using screen scraping to log users into SAML, this isn't ideal and hopefully vendors make this easier in the future. In addition to this there are some things you need to know:
 
-1. AWS only permits session tokens being issued with a duration of up to 3600 seconds (1 hour), this is constrained by the [STS AssumeRoleWithSAML API](http://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithSAML.html) call and `DurationSeconds` field.
+1. AWS defaults to session tokens being issued with a duration of up to 3600 seconds (1 hour), this can now be configured as per [Enable Federated API Access to your AWS Resources for up to 12 hours Using IAM Roles](https://aws.amazon.com/blogs/security/enable-federated-api-access-to-your-aws-resources-for-up-to-12-hours-using-iam-roles/) and `--session-duration` flag.
 2. Every SAML provider is different, the login process, MFA support is pluggable and therefore some work may be needed to integrate with your identity server
 
 # Install
@@ -76,20 +76,25 @@ usage: saml2aws [<flags>] <command> [<args> ...]
 A command line tool to help with SAML access to the AWS token service.
 
 Flags:
-      --help                   Show context-sensitive help (also try --help-long and --help-man).
+      --help                   Show context-sensitive help (also try --help-long
+                               and --help-man).
       --version                Show application version.
       --verbose                Enable verbose logging
-  -i, --provider=PROVIDER      This flag it is obsolete see https://github.com/Versent/saml2aws#adding-idp-accounts.
+  -i, --provider=PROVIDER      This flag it is obsolete see
+                               https://github.com/Versent/saml2aws#adding-idp-accounts.
   -a, --idp-account="default"  The name of the configured IDP account
-      --idp-provider=IDP-PROVIDER
+      --idp-provider=IDP-PROVIDER  
                                The configured IDP provider
-      --mfa="Auto"             The name of the mfa
+      --mfa=MFA                The name of the mfa
   -s, --skip-verify            Skip verification of server certificate.
       --url=URL                The URL of the SAML IDP server used to login.
       --username=USERNAME      The username used to login.
+      --password=PASSWORD      The password used to login.
       --role=ROLE              The ARN of the role to assume.
       --aws-urn=AWS-URN        The URN used by SAML when you login.
       --skip-prompt            Skip prompting for parameters during login.
+      --session-duration=SESSION-DURATION  
+                               The duration of your AWS Session.
 
 Commands:
   help [<command>...]
@@ -103,14 +108,15 @@ Commands:
   login [<flags>]
     Login to a SAML 2.0 IDP and convert the SAML assertion to an STS token.
 
-        --password=PASSWORD  The password used to login.
-    -p, --profile="saml"     The AWS profile to save the temporary credentials
+    -p, --profile="saml"  The AWS profile to save the temporary credentials
 
   exec [<flags>] [<command>...]
     Exec the supplied command with env vars from STS token.
 
-        --password=PASSWORD  The password used to login.
-    -p, --profile="saml"     The AWS profile to save the temporary credentials
+    -p, --profile="saml"  The AWS profile to save the temporary credentials
+
+  list-roles
+    List available role ARNs.
 
 ```
 

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -60,6 +60,7 @@ func main() {
 	app.Flag("role", "The ARN of the role to assume.").StringVar(&commonFlags.RoleArn)
 	app.Flag("aws-urn", "The URN used by SAML when you login.").StringVar(&commonFlags.AmazonWebservicesURN)
 	app.Flag("skip-prompt", "Skip prompting for parameters during login.").BoolVar(&commonFlags.SkipPrompt)
+	app.Flag("session-duration", "The duration of your AWS Session.").IntVar(&commonFlags.SessionDuration)
 
 	// `configure` command and settings
 	cmdConfigure := app.Command("configure", "Configure a new IDP account.")

--- a/pkg/awsconfig/awsconfig_test.go
+++ b/pkg/awsconfig/awsconfig_test.go
@@ -4,11 +4,15 @@ import (
 	"os"
 	"testing"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/stretchr/testify/assert"
 )
 
 func TestUpdateSamlConfig(t *testing.T) {
 	os.Remove(".credentials")
+
+	logrus.SetLevel(logrus.DebugLevel)
 
 	sharedCreds := &CredentialsProvider{".credentials", "saml"}
 
@@ -16,14 +20,21 @@ func TestUpdateSamlConfig(t *testing.T) {
 	assert.Nil(t, err)
 	assert.True(t, exist)
 
-	err = sharedCreds.Save("testid", "testsecret", "testtoken")
+	awsCreds := &AWSCredentials{
+		AWSAccessKey:     "testid",
+		AWSSecretKey:     "testsecret",
+		AWSSessionToken:  "testtoken",
+		AWSSecurityToken: "testtoken",
+	}
+
+	err = sharedCreds.Save(awsCreds)
 	assert.Nil(t, err)
 
-	id, secret, token, err := sharedCreds.Load()
+	awsCreds, err = sharedCreds.Load()
 	assert.Nil(t, err)
-	assert.Equal(t, "testid", id)
-	assert.Equal(t, "testsecret", secret)
-	assert.Equal(t, "testtoken", token)
+	assert.Equal(t, "testid", awsCreds.AWSAccessKey)
+	assert.Equal(t, "testsecret", awsCreds.AWSSecretKey)
+	assert.Equal(t, "testtoken", awsCreds.AWSSessionToken)
 
 	os.Remove(".credentials")
 }

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -19,6 +19,10 @@ const (
 	// DefaultAmazonWebservicesURN URN used when authenticating to aws using SAML
 	// NOTE: This only needs to be changed to log into GovCloud
 	DefaultAmazonWebservicesURN = "urn:amazon:webservices"
+
+	// DefaultSessionDuration this is the default session duration which can be overridden in the AWS console
+	// see https://aws.amazon.com/blogs/security/enable-federated-api-access-to-your-aws-resources-for-up-to-12-hours-using-iam-roles/
+	DefaultSessionDuration = 3600
 )
 
 // IDPAccount saml IDP account
@@ -30,6 +34,7 @@ type IDPAccount struct {
 	SkipVerify           bool   `ini:"skip_verify"`
 	Timeout              int    `ini:"timeout"`
 	AmazonWebservicesURN string `ini:"aws_urn"`
+	SessionDuration      int    `ini:"aws_session_duration"`
 }
 
 // Validate validate the required / expected fields are set
@@ -58,6 +63,7 @@ func (ia *IDPAccount) Validate() error {
 func NewIDPAccount() *IDPAccount {
 	return &IDPAccount{
 		AmazonWebservicesURN: DefaultAmazonWebservicesURN,
+		SessionDuration:      DefaultSessionDuration,
 	}
 }
 

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -32,12 +32,14 @@ func TestNewConfigManagerLoad(t *testing.T) {
 		Provider:             "keycloak",
 		MFA:                  "sms",
 		AmazonWebservicesURN: DefaultAmazonWebservicesURN,
+		SessionDuration:      3600,
 	}, idpAccount)
 
 	idpAccount, err = cfgm.LoadIDPAccount("test1234")
 	require.Nil(t, err)
 	require.Equal(t, &IDPAccount{
 		AmazonWebservicesURN: DefaultAmazonWebservicesURN,
+		SessionDuration:      3600,
 	}, idpAccount)
 }
 
@@ -56,6 +58,7 @@ func TestNewConfigManagerLoadVerify(t *testing.T) {
 		Provider:             "keycloak",
 		MFA:                  "sms",
 		AmazonWebservicesURN: DefaultAmazonWebservicesURN,
+		SessionDuration:      3600,
 	}, idpAccount)
 
 	idpAccount, err = cfgm.LoadVerifyIDPAccount("test1234")

--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -3,11 +3,12 @@ package dump
 import (
 	"net/http"
 	"net/http/httputil"
+	"os"
 )
 
 // RequestString helper method to dump the http request
 func RequestString(req *http.Request) string {
-	data, err := httputil.DumpRequest(req, false)
+	data, err := httputil.DumpRequest(req, dumpContentEnable())
 
 	if err != nil {
 		return ""
@@ -18,11 +19,15 @@ func RequestString(req *http.Request) string {
 
 // ResponseString helper method to dump the http response
 func ResponseString(res *http.Response) string {
-	data, err := httputil.DumpResponse(res, false)
+	data, err := httputil.DumpResponse(res, dumpContentEnable())
 
 	if err != nil {
 		return ""
 	}
 
 	return string(data)
+}
+
+func dumpContentEnable() bool {
+	return os.Getenv("DUMP_CONTENT") == "true"
 }

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -1,6 +1,8 @@
 package flags
 
-import "github.com/versent/saml2aws/pkg/cfg"
+import (
+	"github.com/versent/saml2aws/pkg/cfg"
+)
 
 // CommonFlags flags common to all of the `saml2aws` commands (except `help`)
 type CommonFlags struct {
@@ -12,6 +14,7 @@ type CommonFlags struct {
 	Password             string
 	RoleArn              string
 	AmazonWebservicesURN string
+	SessionDuration      int
 	SkipPrompt           bool
 	SkipVerify           bool
 }
@@ -51,5 +54,9 @@ func ApplyFlagOverrides(commonFlags *CommonFlags, account *cfg.IDPAccount) {
 
 	if commonFlags.AmazonWebservicesURN != "" {
 		account.AmazonWebservicesURN = commonFlags.AmazonWebservicesURN
+	}
+
+	if commonFlags.SessionDuration != 0 {
+		account.SessionDuration = commonFlags.SessionDuration
 	}
 }

--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -160,6 +160,8 @@ func (oc *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 		return samlAssertion, errors.Wrap(err, "unable to locate saml response")
 	}
 
+	logger.WithField("samlAssertion", samlAssertion).Debug("complete")
+
 	return samlAssertion, nil
 }
 

--- a/pkg/shell/env.go
+++ b/pkg/shell/env.go
@@ -1,14 +1,18 @@
 package shell
 
-import "fmt"
+import (
+	"fmt"
+
+	"github.com/versent/saml2aws/pkg/awsconfig"
+)
 
 // BuildEnvVars build an array of env vars in the format required for exec
-func BuildEnvVars(id, secret, token string) []string {
+func BuildEnvVars(awsCreds *awsconfig.AWSCredentials) []string {
 	return []string{
-		fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", id),
-		fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", secret),
-		fmt.Sprintf("AWS_SESSION_TOKEN=%s", token),
-		fmt.Sprintf("AWS_SECURITY_TOKEN=%s", token),
-		fmt.Sprintf("EC2_SECURITY_TOKEN=%s", token),
+		fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", awsCreds.AWSAccessKey),
+		fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", awsCreds.AWSSecretKey),
+		fmt.Sprintf("AWS_SESSION_TOKEN=%s", awsCreds.AWSSessionToken),
+		fmt.Sprintf("AWS_SECURITY_TOKEN=%s", awsCreds.AWSSecurityToken),
+		fmt.Sprintf("EC2_SECURITY_TOKEN=%s", awsCreds.AWSSecurityToken),
 	}
 }

--- a/pkg/shell/env_test.go
+++ b/pkg/shell/env_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/versent/saml2aws/pkg/awsconfig"
 )
 
 func TestBuildEnvVars(t *testing.T) {
@@ -16,5 +17,12 @@ func TestBuildEnvVars(t *testing.T) {
 		"EC2_SECURITY_TOKEN=567",
 	}
 
-	assert.Equal(t, expectedArray, BuildEnvVars("123", "345", "567"))
+	awsCreds := &awsconfig.AWSCredentials{
+		AWSAccessKey:     "123",
+		AWSSecretKey:     "345",
+		AWSSecurityToken: "567",
+		AWSSessionToken:  "567",
+	}
+
+	assert.Equal(t, expectedArray, BuildEnvVars(awsCreds))
 }

--- a/saml_test.go
+++ b/saml_test.go
@@ -15,3 +15,12 @@ func TestExtractAwsRoles(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Len(t, roles, 2)
 }
+
+func TestExtractSessionDuration(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/assertion.xml")
+	assert.Nil(t, err)
+
+	duration, err := ExtractSessionDuration(data)
+	assert.Nil(t, err)
+	assert.Equal(t, int64(28800), duration)
+}

--- a/testdata/assertion.xml
+++ b/testdata/assertion.xml
@@ -44,6 +44,9 @@
         <AttributeValue>arn:aws:iam::123123123123:saml-provider/ExampleADFS,arn:aws:iam::123123123123:role/AWS-Admin-CloudOPSBuild</AttributeValue>
         <AttributeValue>arn:aws:iam::123123123123:saml-provider/ExampleADFS,arn:aws:iam::123123123123:role/AWS-Admin-CloudOPSNonProd</AttributeValue>
       </Attribute>
+      <saml2:Attribute Name="https://aws.amazon.com/SAML/Attributes/SessionDuration" NameFormat="urn:oasis:names:tc:SAML:2.0:attrname-format:basic">
+        <saml2:AttributeValue xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:type="xs:string">28800</saml2:AttributeValue>
+      </saml2:Attribute>
     </AttributeStatement>
     <AuthnStatement AuthnInstant="2016-09-10T02:54:39.227Z" SessionIndex="_f85be5f5-584c-4711-8c9d-5b13c4c49f89">
       <AuthnContext>


### PR DESCRIPTION
see https://aws.amazon.com/blogs/security/enable-federated-api-access-to-your-aws-resources-for-up-to-12-hours-using-iam-roles/

* Refactor aws config to use structures
* Added saving of the expiry time for sessions and principal ARN
* Enable content dumping using env DUMP_CONTENT=true while debugging