### PR TITLE
http(status) Add http status check to Ping and Okta providers.

### DIFF
--- a/pkg/provider/http_test.go
+++ b/pkg/provider/http_test.go
@@ -1,0 +1,72 @@
+package provider
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestClientDoGetOK(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("OK"))
+	}))
+	defer ts.Close()
+
+	rt := NewDefaultTransport(false)
+
+	hc, err := NewHTTPClient(rt)
+	require.Nil(t, err)
+
+	// hc := &HTTPClient{Client: http.Client{}}
+
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	require.Nil(t, err)
+
+	res, err := hc.Do(req)
+	require.Nil(t, err)
+
+	require.Equal(t, 200, res.StatusCode)
+}
+
+func TestClientDisableRedirect(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(302)
+		w.Write([]byte("OK"))
+	}))
+	defer ts.Close()
+
+	rt := NewDefaultTransport(false)
+
+	hc, err := NewHTTPClient(rt)
+	require.Nil(t, err)
+
+	hc.DisableFollowRedirect()
+
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	require.Nil(t, err)
+
+	res, err := hc.Do(req)
+	require.Error(t, err)
+	require.Nil(t, res)
+}
+
+func TestClientDoResponseCheck(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(400)
+		w.Write([]byte("OK"))
+	}))
+	defer ts.Close()
+
+	hc := &HTTPClient{Client: http.Client{}}
+
+	hc.CheckResponseStatus = SuccessOrRedirectResponseValidator
+
+	req, err := http.NewRequest("GET", ts.URL, nil)
+	require.Nil(t, err)
+
+	res, err := hc.Do(req)
+	require.Error(t, err)
+	require.Equal(t, 400, res.StatusCode)
+}

--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -71,6 +71,10 @@ func New(idpAccount *cfg.IDPAccount) (*Client, error) {
 		return nil, errors.Wrap(err, "error building http client")
 	}
 
+	// assign a response validator to ensure all responses are either success or a redirect
+	// this is to avoid have explicit checks for every single response
+	client.CheckResponseStatus = provider.SuccessOrRedirectResponseValidator
+
 	return &Client{
 		client: client,
 	}, nil
@@ -518,8 +522,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, resp string) (string, error) {
 			return "", errors.Wrap(err, "error retrieving body from response")
 		}
 
-		resp = string(body)
-		return gjson.Get(resp, "sessionToken").String(), nil
+		return gjson.GetBytes(body, "sessionToken").String(), nil
 	}
 
 	// catch all

--- a/pkg/provider/pingfed/pingfed.go
+++ b/pkg/provider/pingfed/pingfed.go
@@ -25,9 +25,6 @@ var logger = logrus.WithField("provider", "pingfed")
 type Client struct {
 	client     *provider.HTTPClient
 	idpAccount *cfg.IDPAccount
-	//authSubmitURL string
-	//samlAssertion string
-	//mfaRequired   bool
 }
 
 // New create a new PingFed client
@@ -40,13 +37,16 @@ func New(idpAccount *cfg.IDPAccount) (*Client, error) {
 		return nil, errors.Wrap(err, "error building http client")
 	}
 
-	//disable default behaviour to follow redirects as we use this to detect mfa
+	// assign a response validator to ensure all responses are either success or a redirect
+	// this is to avoid have explicit checks for every single response
+	client.CheckResponseStatus = provider.SuccessOrRedirectResponseValidator
+
+	//disable default behavior to follow redirects as we use this to detect mfa
 	client.DisableFollowRedirect()
 
 	return &Client{
 		client:     client,
 		idpAccount: idpAccount,
-		//mfaRequired: false,
 	}, nil
 }
 


### PR DESCRIPTION
This feature adds an optional response validator which checks the status code is within the success and redirect ranges removing the need to validate every response with this logic explicity.