### PR TITLE
feat(exec) Added the profile ENV vars.

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,10 @@ The exec sub command will export the following environment variables.
 * AWS_SESSION_TOKEN
 * AWS_SECURITY_TOKEN
 * EC2_SECURITY_TOKEN
+* AWS_PROFILE
+* AWS_DEFAULT_PROFILE
+
+Note: That profile environment variables enable you to use `exec` with a script or command which requires an explicit profile.
 
 # Dependencies
 

--- a/cmd/saml2aws/commands/exec.go
+++ b/cmd/saml2aws/commands/exec.go
@@ -62,7 +62,7 @@ func Exec(execFlags *flags.LoginExecFlags, cmdline []string) error {
 		return errors.Wrap(err, "error logging in")
 	}
 
-	return shell.ExecShellCmd(cmdline, shell.BuildEnvVars(awsCreds))
+	return shell.ExecShellCmd(cmdline, shell.BuildEnvVars(awsCreds, account))
 }
 
 func checkToken(profile string) (bool, error) {

--- a/pkg/shell/env.go
+++ b/pkg/shell/env.go
@@ -4,15 +4,18 @@ import (
 	"fmt"
 
 	"github.com/versent/saml2aws/pkg/awsconfig"
+	"github.com/versent/saml2aws/pkg/cfg"
 )
 
 // BuildEnvVars build an array of env vars in the format required for exec
-func BuildEnvVars(awsCreds *awsconfig.AWSCredentials) []string {
+func BuildEnvVars(awsCreds *awsconfig.AWSCredentials, account *cfg.IDPAccount) []string {
 	return []string{
 		fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", awsCreds.AWSAccessKey),
 		fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", awsCreds.AWSSecretKey),
 		fmt.Sprintf("AWS_SESSION_TOKEN=%s", awsCreds.AWSSessionToken),
 		fmt.Sprintf("AWS_SECURITY_TOKEN=%s", awsCreds.AWSSecurityToken),
 		fmt.Sprintf("EC2_SECURITY_TOKEN=%s", awsCreds.AWSSecurityToken),
+		fmt.Sprintf("AWS_PROFILE=%s", account.Profile),
+		fmt.Sprintf("AWS_DEFAULT_PROFILE=%s", account.Profile),
 	}
 }

--- a/pkg/shell/env_test.go
+++ b/pkg/shell/env_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/versent/saml2aws/pkg/awsconfig"
+	"github.com/versent/saml2aws/pkg/cfg"
 )
 
 func TestBuildEnvVars(t *testing.T) {
@@ -15,6 +16,12 @@ func TestBuildEnvVars(t *testing.T) {
 		"AWS_SESSION_TOKEN=567",
 		"AWS_SECURITY_TOKEN=567",
 		"EC2_SECURITY_TOKEN=567",
+		"AWS_PROFILE=saml",
+		"AWS_DEFAULT_PROFILE=saml",
+	}
+
+	account := &cfg.IDPAccount{
+		Profile: "saml",
 	}
 
 	awsCreds := &awsconfig.AWSCredentials{
@@ -24,5 +31,5 @@ func TestBuildEnvVars(t *testing.T) {
 		AWSSessionToken:  "567",
 	}
 
-	assert.Equal(t, expectedArray, BuildEnvVars(awsCreds))
+	assert.Equal(t, expectedArray, BuildEnvVars(awsCreds, account))
 }


### PR DESCRIPTION
This was requested to enable running of scripts or tools which take an explicit aws profile name.