### PR TITLE
refactor(HTTP) Remove simplify request / response logging.

### DIFF
--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -8,7 +8,7 @@ import (
 
 // RequestString helper method to dump the http request
 func RequestString(req *http.Request) string {
-	data, err := httputil.DumpRequest(req, dumpContentEnable())
+	data, err := httputil.DumpRequest(req, ContentEnable())
 
 	if err != nil {
 		return ""
@@ -19,7 +19,7 @@ func RequestString(req *http.Request) string {
 
 // ResponseString helper method to dump the http response
 func ResponseString(res *http.Response) string {
-	data, err := httputil.DumpResponse(res, dumpContentEnable())
+	data, err := httputil.DumpResponse(res, ContentEnable())
 
 	if err != nil {
 		return ""
@@ -28,6 +28,7 @@ func ResponseString(res *http.Response) string {
 	return string(data)
 }
 
-func dumpContentEnable() bool {
+// ContentEnable enable dumping of request / response content
+func ContentEnable() bool {
 	return os.Getenv("DUMP_CONTENT") == "true"
 }

--- a/pkg/provider/adfs/adfs.go
+++ b/pkg/provider/adfs/adfs.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/versent/saml2aws/pkg/cfg"
 	"github.com/versent/saml2aws/pkg/creds"
-	"github.com/versent/saml2aws/pkg/dump"
 	"github.com/versent/saml2aws/pkg/prompter"
 	"github.com/versent/saml2aws/pkg/provider"
 )
@@ -90,15 +89,10 @@ func (ac *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	logger.WithField("authSubmitURL", authSubmitURL).WithField("req", dump.RequestString(req)).Debug("POST")
-
 	res, err = ac.client.Do(req)
 	if err != nil {
 		return samlAssertion, errors.Wrap(err, "error retrieving login form results")
 	}
-
-	//log.Printf("res code = %v status = %s", res.StatusCode, res.Status)
-	logger.WithField("authSubmitURL", authSubmitURL).WithField("res", dump.ResponseString(res)).Debug("POST")
 
 	switch ac.idpAccount.MFA {
 	case "VIP":

--- a/pkg/provider/keycloak/keycloak.go
+++ b/pkg/provider/keycloak/keycloak.go
@@ -13,7 +13,6 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/versent/saml2aws/pkg/cfg"
 	"github.com/versent/saml2aws/pkg/creds"
-	"github.com/versent/saml2aws/pkg/dump"
 	"github.com/versent/saml2aws/pkg/prompter"
 	"github.com/versent/saml2aws/pkg/provider"
 
@@ -101,8 +100,6 @@ func (kc *Client) getLoginForm(loginDetails *creds.LoginDetails) (string, url.Va
 		return "", nil, errors.Wrap(err, "error retrieving form")
 	}
 
-	logger.WithField("status", res.StatusCode).WithField("url", loginDetails.URL).WithField("res", dump.ResponseString(res)).Debug("GET")
-
 	doc, err := goquery.NewDocumentFromResponse(res)
 	if err != nil {
 		return "", nil, errors.Wrap(err, "failed to build document from response")
@@ -136,8 +133,6 @@ func (kc *Client) postLoginForm(authSubmitURL string, authForm url.Values) ([]by
 		return nil, errors.Wrap(err, "error retrieving login form")
 	}
 
-	logger.WithField("status", res.StatusCode).WithField("url", authSubmitURL).WithField("res", dump.ResponseString(res)).Debug("POST")
-
 	data, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return nil, errors.Wrap(err, "error retrieving body")
@@ -163,14 +158,10 @@ func (kc *Client) postTotpForm(totpSubmitURL string, doc *goquery.Document) (*go
 
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-	logger.WithField("url", totpSubmitURL).WithField("req", dump.RequestString(req)).Debug("POST")
-
 	res, err := kc.client.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "error retrieving content")
 	}
-
-	logger.WithField("status", res.StatusCode).WithField("url", totpSubmitURL).WithField("res", dump.ResponseString(res)).Debug("POST")
 
 	doc, err = goquery.NewDocumentFromResponse(res)
 	if err != nil {

--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -11,7 +11,6 @@ import (
 	"time"
 
 	"github.com/sirupsen/logrus"
-	"github.com/versent/saml2aws/pkg/dump"
 	"github.com/versent/saml2aws/pkg/prompter"
 
 	"github.com/PuerkitoBio/goquery"
@@ -115,8 +114,6 @@ func (oc *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 		return samlAssertion, errors.Wrap(err, "error retrieving auth response")
 	}
 
-	logger.WithField("status", res.StatusCode).WithField("authSubmitURL", authSubmitURL).WithField("res", dump.ResponseString(res)).Debug("POST")
-
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
 		return samlAssertion, errors.Wrap(err, "error retrieving body from response")
@@ -164,7 +161,7 @@ func (oc *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 		return samlAssertion, errors.Wrap(err, "unable to locate saml response")
 	}
 
-	logger.WithField("samlAssertion", samlAssertion).Debug("complete")
+	logger.Debug("auth complete")
 
 	return samlAssertion, nil
 }
@@ -224,8 +221,6 @@ func verifyMfa(oc *Client, oktaOrgHost string, resp string) (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "error retrieving verify response")
 	}
-
-	logger.WithField("status", res.StatusCode).WithField("res", dump.ResponseString(res)).Debug("POST")
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {


### PR DESCRIPTION
Based on feedback from users that the verbose was inconsistant across providers I added logging to the client where it should have been and removed all the shitty logging statements from all over the providers.