### PR TITLE
Add global mfa-token flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ Flags:
       --url=URL                The URL of the SAML IDP server used to login.
       --username=USERNAME      The username used to login.
       --password=PASSWORD      The password used to login.
+      --mfa-token=MFA-TOKEN    The current MFA token (supported in Keycloak, ADFS).
       --role=ROLE              The ARN of the role to assume.
       --aws-urn=AWS-URN        The URN used by SAML when you login.
       --skip-prompt            Skip prompting for parameters during login.

--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -124,7 +124,7 @@ func resolveLoginDetails(account *cfg.IDPAccount, loginFlags *flags.LoginExecFla
 
 	// fmt.Printf("loginFlags %+v\n", loginFlags)
 
-	loginDetails := &creds.LoginDetails{URL: account.URL, Username: account.Username}
+	loginDetails := &creds.LoginDetails{URL: account.URL, Username: account.Username, MFAToken: loginFlags.CommonFlags.MFAToken}
 
 	fmt.Printf("Using IDP Account %s to access %s %s\n", loginFlags.CommonFlags.IdpAccount, account.Provider, account.URL)
 

--- a/cmd/saml2aws/commands/login_test.go
+++ b/cmd/saml2aws/commands/login_test.go
@@ -12,7 +12,7 @@ import (
 
 func TestResolveLoginDetailsWithFlags(t *testing.T) {
 
-	commonFlags := &flags.CommonFlags{URL: "https://id.example.com", Username: "wolfeidau", Password: "testtestlol", SkipPrompt: true}
+	commonFlags := &flags.CommonFlags{URL: "https://id.example.com", Username: "wolfeidau", Password: "testtestlol", MFAToken: "123456", SkipPrompt: true}
 	loginFlags := &flags.LoginExecFlags{CommonFlags: commonFlags}
 
 	idpa := &cfg.IDPAccount{
@@ -24,7 +24,7 @@ func TestResolveLoginDetailsWithFlags(t *testing.T) {
 	loginDetails, err := resolveLoginDetails(idpa, loginFlags)
 
 	assert.Empty(t, err)
-	assert.Equal(t, &creds.LoginDetails{Username: "wolfeidau", Password: "testtestlol", URL: "https://id.example.com"}, loginDetails)
+	assert.Equal(t, &creds.LoginDetails{Username: "wolfeidau", Password: "testtestlol", URL: "https://id.example.com", MFAToken: "123456"}, loginDetails)
 }
 
 func TestResolveRoleSingleEntry(t *testing.T) {

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -57,6 +57,7 @@ func main() {
 	app.Flag("url", "The URL of the SAML IDP server used to login.").StringVar(&commonFlags.URL)
 	app.Flag("username", "The username used to login.").Envar("SAML2AWS_USERNAME").StringVar(&commonFlags.Username)
 	app.Flag("password", "The password used to login.").Envar("SAML2AWS_PASSWORD").StringVar(&commonFlags.Password)
+	app.Flag("mfa-token", "The current MFA token (supported in Keycloak, ADFS).").Envar("SAML2AWS_MFA_TOKEN").StringVar(&commonFlags.MFAToken)
 	app.Flag("role", "The ARN of the role to assume.").StringVar(&commonFlags.RoleArn)
 	app.Flag("aws-urn", "The URN used by SAML when you login.").StringVar(&commonFlags.AmazonWebservicesURN)
 	app.Flag("skip-prompt", "Skip prompting for parameters during login.").BoolVar(&commonFlags.SkipPrompt)

--- a/pkg/creds/creds.go
+++ b/pkg/creds/creds.go
@@ -6,6 +6,7 @@ import "errors"
 type LoginDetails struct {
 	Username string
 	Password string
+	MFAToken string
 	URL      string
 }
 

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -9,6 +9,7 @@ type CommonFlags struct {
 	IdpAccount           string
 	IdpProvider          string
 	MFA                  string
+	MFAToken             string
 	URL                  string
 	Username             string
 	Password             string

--- a/pkg/provider/keycloak/keycloak_test.go
+++ b/pkg/provider/keycloak/keycloak_test.go
@@ -10,9 +10,11 @@ import (
 
 	"github.com/PuerkitoBio/goquery"
 
-	"github.com/stretchr/testify/require"
+	"github.com/versent/saml2aws/mocks"
 	"github.com/versent/saml2aws/pkg/creds"
+	"github.com/versent/saml2aws/pkg/prompter"
 	"github.com/versent/saml2aws/pkg/provider"
+	"github.com/stretchr/testify/require"
 )
 
 const (
@@ -78,10 +80,41 @@ func TestClient_postTotpForm(t *testing.T) {
 	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(data))
 	require.Nil(t, err)
 
+	pr := &mocks.Prompter{}
+	prompter.SetPrompter(pr)
+
+	pr.Mock.On("RequestSecurityCode", "000000").Return("123456")
+
 	mfaToken := ""
 	kc := Client{client: &provider.HTTPClient{Client: http.Client{}}}
 
 	kc.postTotpForm(ts.URL, mfaToken, doc)
+
+	pr.Mock.AssertCalled(t, "RequestSecurityCode", "000000")
+}
+
+func TestClient_postTotpFormWithProvidedMFAToken(t *testing.T) {
+
+	data, err := ioutil.ReadFile("example/assertion.html")
+	require.Nil(t, err)
+
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write(data)
+	}))
+	defer ts.Close()
+
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(data))
+	require.Nil(t, err)
+
+	pr := &mocks.Prompter{}
+	prompter.SetPrompter(pr)
+
+	mfaToken := "123456"
+	kc := Client{client: &provider.HTTPClient{Client: http.Client{}}}
+
+	kc.postTotpForm(ts.URL, mfaToken, doc)
+
+	pr.Mock.AssertNumberOfCalls(t, "RequestSecurityCode", 0)
 }
 
 func TestClient_containsTotpForm(t *testing.T) {

--- a/pkg/provider/keycloak/keycloak_test.go
+++ b/pkg/provider/keycloak/keycloak_test.go
@@ -11,7 +11,6 @@ import (
 	"github.com/PuerkitoBio/goquery"
 
 	"github.com/stretchr/testify/require"
-	"github.com/versent/saml2aws/mocks"
 	"github.com/versent/saml2aws/pkg/creds"
 	"github.com/versent/saml2aws/pkg/provider"
 )
@@ -78,13 +77,11 @@ func TestClient_postTotpForm(t *testing.T) {
 
 	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(data))
 	require.Nil(t, err)
-	pr := &mocks.Prompter{}
 
-	pr.Mock.On("RequestSecurityCode", "000000").Return("111222")
-
+	mfaToken := ""
 	kc := Client{client: &provider.HTTPClient{Client: http.Client{}}}
 
-	kc.postTotpForm(ts.URL, doc)
+	kc.postTotpForm(ts.URL, mfaToken, doc)
 }
 
 func TestClient_containsTotpForm(t *testing.T) {


### PR DESCRIPTION
This flag allows easier automation for running saml2aws with
--skip-prompt. Only Keycloak and ADFS are currently supported.

---
In my exact use case, [saml2aws-auto](https://github.com/Rukenshia/saml2aws-auto), I currently have to rely on passing the MFA token by sending it through `stdin`. This does, however, not work reliably on Windows. I think this addition is quite useful for `--skip-prompt` use cases.