### PR TITLE
fix(pkg/dump) Use httputil.DumpRequestOut, per docs.

### DIFF
--- a/pkg/dump/dump.go
+++ b/pkg/dump/dump.go
@@ -8,7 +8,7 @@ import (
 
 // RequestString helper method to dump the http request
 func RequestString(req *http.Request) string {
-	data, err := httputil.DumpRequest(req, ContentEnable())
+	data, err := httputil.DumpRequestOut(req, ContentEnable())
 
 	if err != nil {
 		return ""


### PR DESCRIPTION
The docs say (https://golang.org/pkg/net/http/httputil/#DumpRequestOut):
> DumpRequestOut is like DumpRequest but for outgoing client requests.

I don't actually see any difference in output when using `DUMP_CONTENT=true saml2aws login -a MY_PROVIDER --verbose`, but the docs seem pretty unambiguous that `DumpRequestOut` is the right API to use here, so I figure it's a safe change.