### PR TITLE
Add Okta-specific notes.

### DIFF
--- a/README.md
+++ b/README.md
@@ -272,6 +272,12 @@ The second emits the content of requests and responses, this includes authentica
 DUMP_CONTENT=true saml2aws login --verbose
 ```
 
+# IDP-specific notes
+
+Additional IDP-specific notes are available for:
+
+* [Okta](pkg/provider/okta/README.md)
+
 # License
 
 This code is Copyright (c) 2018 [Versent](http://versent.com.au) and released under the MIT license. All rights not explicitly granted in the MIT license are reserved. See the included LICENSE.md file for more details.

--- a/pkg/provider/okta/README.md
+++ b/pkg/provider/okta/README.md
@@ -1,0 +1,19 @@
+# Okta provider
+
+## Instructions
+
+Retrieve the AWS application URL from your Okta tenant. This will (may) look something like:
+
+```
+https://$YOUR_ORGANIZATION.okta.com/home/amazon_aws/$OKTA_APPLICATION_ID/$OKTA_OTHER_ID
+```
+
+The path segments `/home/amazon_aws` in the above URL may vary.
+
+## Features
+
+* Supports MFA (Okta Push, Okta TOTP, Duo, and Google Authenticator), when configured at *organization level*.
+
+## Limitations
+
+* Does **not** support application-level MFA, per [issue #118](https://github.com/Versent/saml2aws/issues/118#issuecomment-355688008)


### PR DESCRIPTION
Maybe this is unnecessary, but I spent a bit too much time stumbling around before I realized what URL `saml2aws` wants for Okta. The symptom when providing the base URL (e.g., `https://$YOUR_ORG.okta.com`) instead of the AWS application URL (e.g., `https://$YOUR_ORG.okta.com/home/amazon_aws/$OKTA_APP_ID/$SOME_OTHER_ID`) is that `saml2aws` fails with the error:

```
Response did not contain a valid SAML assertion
Please check your username and password is correct
```

Which is technically correct, but is not at all helpful for diagnosing that the username and password are not at all the problem.

In retrospect it is obvious, but a little note like this would have saved me some time.