### PR TITLE
Fix issue with okta MFA approval

### DIFF
--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -460,7 +460,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, resp string) (string, error) {
 				resp := string(body)
 
 				duoTxResult = gjson.Get(resp, "response.result").String()
-				duoTxCookie = gjson.Get(resp, "response.cookie").String()
+				duoResultURL := gjson.Get(resp, "response.result_url").String()
 
 				fmt.Println(gjson.Get(resp, "response.status").String())
 
@@ -469,6 +469,30 @@ func verifyMfa(oc *Client, oktaOrgHost string, resp string) (string, error) {
 				}
 
 				if duoTxResult == "SUCCESS" {
+					duoRequestURL := fmt.Sprintf("https://%s%s", duoHost, duoResultURL)
+					req, err = http.NewRequest("POST", duoRequestURL, strings.NewReader(duoForm.Encode()))
+					if err != nil {
+						return "", errors.Wrap(err, "error constructing request object to result url")
+					}
+
+					req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+					res, err = oc.client.Do(req)
+					if err != nil {
+						return "", errors.Wrap(err, "error retrieving duo result response")
+					}
+
+					body, err = ioutil.ReadAll(res.Body)
+					if err != nil {
+						return "", errors.Wrap(err, "duoResultSubmit: error retrieving body from response")
+					}
+
+					resp := string(body)
+					duoTxCookie = gjson.Get(resp, "response.cookie").String()
+					if duoTxCookie == "" {
+						return "", errors.Wrap(err, "duoResultSubmit: Unable to get response.cookie")
+					}
+
 					break
 				}
 			}


### PR DESCRIPTION
@wolfeidau @mcleane 
- Okta introduced an additional http call before we can retrieve cookie and complete the auth process 
- This fix implements that http call and retrieve cookie from it.