### PR TITLE
Fixed broken Duo MFA in Shibboleth based on Okta change in #214

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ vendor
 /stage
 coverage.txt
 .ctags
+.vscode

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The process goes something like this:
   * [Okta](pkg/provider/okta/README.md)
   * KeyCloak + (TOTP)
   * [Google Apps](pkg/provider/googleapps/README.md)
-  * Shibboleth
+  * [Shibboleth](pkg/provider/shibboleth/README.md)
 * AWS SAML Provider configured
 
 # Caveats

--- a/pkg/provider/shibboleth/README.md
+++ b/pkg/provider/shibboleth/README.md
@@ -1,0 +1,15 @@
+# Shibboleth provider
+
+## Instructions
+
+Uses default Shibboleth 3.3 pathing for the entry point.
+e.g. if url is "https://idp.example.com" and the aws_urn is the default, this will construct the following URL to use.
+https://idp.example.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices
+
+## Features
+
+* Prompts for Duo MFA when logging in when "mfa" is set to Auto. Options are Duo Push, Phone Call, and Passcode.
+
+## Limitations
+
+* Has only been tested with Shibboleth 3.3 with Duo MFA enabled.


### PR DESCRIPTION
Duo recently made a change that broke the Okta and Shibboleth providers Duo MFA implementations.

This PR is to fix the Shibboleth provider based on the changes made to the Okta provider in #214.

In the Shibboleth provider, I've moved the Duo MFA verification logic into a separate function which is basically lines 315-499 of the Okta provider. Perhaps a future PR could be to refactor both Shibboleth and Okta providers to use shared code with this function.

Also added readme for Shibboleth provider.