### PR TITLE
dont prompt for creds if they are currently valid

### DIFF
--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -42,6 +42,11 @@ func Login(loginFlags *flags.LoginExecFlags) error {
 		return nil
 	}
 
+	if !sharedCreds.Expired() && !loginFlags.Force {
+		fmt.Println("credentials are not expired skipping")
+		return nil
+	}
+
 	loginDetails, err := resolveLoginDetails(account, loginFlags)
 	if err != nil {
 		fmt.Printf("%+v\n", err)

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -76,6 +76,7 @@ func main() {
 	loginFlags := new(flags.LoginExecFlags)
 	loginFlags.CommonFlags = commonFlags
 	cmdLogin.Flag("profile", "The AWS profile to save the temporary credentials").Short('p').StringVar(&commonFlags.Profile)
+	cmdLogin.Flag("force", "Refreshes credentials even if not expired").BoolVar(&loginFlags.Force)
 
 	// `exec` command and settings
 	cmdExec := app.Command("exec", "Exec the supplied command with env vars from STS token.")

--- a/pkg/awsconfig/awsconfig.go
+++ b/pkg/awsconfig/awsconfig.go
@@ -110,6 +110,16 @@ func (p *CredentialsProvider) Load() (*AWSCredentials, error) {
 	return awsCreds, nil
 }
 
+// Expired checks if the current credentials are expired
+func (p *CredentialsProvider) Expired() bool {
+	creds, err := p.Load()
+	if err != nil {
+		return true
+	}
+
+	return time.Now().After(creds.Expires)
+}
+
 // ensureConfigExists verify that the config file exists
 func (p *CredentialsProvider) ensureConfigExists() error {
 	filename, err := p.resolveFilename()

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -28,6 +28,7 @@ type CommonFlags struct {
 // LoginExecFlags flags for the Login / Exec commands
 type LoginExecFlags struct {
 	CommonFlags *CommonFlags
+	Force       bool
 }
 
 // ApplyFlagOverrides overrides IDPAccount with command line settings


### PR DESCRIPTION
fixes #227 

I currently use `aws-mfa` and I have a bash function that called switch.  It sets AWS_PROFILE and runs aws-mfa.  If my credentials are expired it will prompt me for my MFA.  If my credentials are still valid it moves along.

Currently with `saml2aws` I have no command I can run that says only reauthenticate me when my credentials have expired.