### PR TITLE
allow the user to specify the mfa in the configuration if they have m…

### DIFF
--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -46,6 +46,7 @@ var (
 // Client is a wrapper representing a Okta SAML client
 type Client struct {
 	client *provider.HTTPClient
+	mfa    string
 }
 
 // AuthRequest represents an mfa okta request
@@ -76,6 +77,7 @@ func New(idpAccount *cfg.IDPAccount) (*Client, error) {
 
 	return &Client{
 		client: client,
+		mfa:    idpAccount.MFA,
 	}, nil
 }
 
@@ -185,6 +187,15 @@ func verifyMfa(oc *Client, oktaOrgHost string, resp string) (string, error) {
 			mfaOptions = append(mfaOptions, val)
 		} else {
 			mfaOptions = append(mfaOptions, "UNSUPPORTED: "+identifier)
+		}
+	}
+
+	if oc.mfa != "AUTO" {
+		for _, val := range mfaOptions {
+			if strings.HasPrefix(val, oc.mfa) {
+				mfaOptions = []string{val}
+				break
+			}
 		}
 	}
 	if len(mfaOptions) > 1 {

--- a/saml2aws.go
+++ b/saml2aws.go
@@ -28,10 +28,10 @@ var MFAsByProvider = ProviderList{
 	"Ping":       []string{"Auto"},        // automatically detects PingID
 	"PingOne":    []string{"Auto"},        // automatically detects PingID
 	"JumpCloud":  []string{"Auto"},
-	"Okta":       []string{"Auto"},                       // automatically detects DUO, SMS and ToTP
-	"OneLogin":   []string{"Auto", "OLP", "SMS", "TOTP"}, // automatically detects OneLogin Protect, SMS and ToTP
-	"KeyCloak":   []string{"Auto"},                       // automatically detects ToTP
-	"GoogleApps": []string{"Auto"},                       // automatically detects ToTP
+	"Okta":       []string{"Auto", "PUSH", "DUO", "SMS", "TOTP", "OKTA"}, // automatically detects DUO, SMS and ToTP
+	"OneLogin":   []string{"Auto", "OLP", "SMS", "TOTP"},                 // automatically detects OneLogin Protect, SMS and ToTP
+	"KeyCloak":   []string{"Auto"},                                       // automatically detects ToTP
+	"GoogleApps": []string{"Auto"},                                       // automatically detects ToTP
 	"Shibboleth": []string{"Auto"},
 }
 


### PR DESCRIPTION
…ultiple options from okta

Resolves #228 

The options I gave may not make total sense.  My specific usecase is I'm currently always prompted for which MFA option to use as Okta only supports Auto.

```
? Select which MFA option to use  [Use arrows to move, type to filter]
❯ PUSH MFA authentication
  Okta MFA authentication
```

With this change I can specify mfa = PUSH or mfa = Okta in the configuration and it will select the correct one without prompting me.