### PR TITLE
Swapped the order to prefer Duo Push over Passcode.

### DIFF
--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -367,8 +367,8 @@ func verifyMfa(oc *Client, oktaOrgHost string, resp string) (string, error) {
 		var token string
 
 		var duoMfaOptions = []string{
-			"Passcode",
 			"Duo Push",
+			"Passcode",
 		}
 
 		duoMfaOption := prompter.Choose("Select a DUO MFA Option", duoMfaOptions)


### PR DESCRIPTION
I don't know anyone who uses Passcode anymore. Push should be the default.

If there's anyone who hates this change, we could make it a configuration item, but the code is not set up to do that right now.