### PR TITLE
Add PSU provider

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,7 +2,7 @@
 
 
 [[projects]]
-  digest = "1:f8810373a82e746e36ae75d76e979562b19640986c2fc2429e44776c70bd1839"
+  digest = "1:02af1b0c1b08031a940a6c6ad1f55c292c84a7cdd3c435d5c841bcee46819f3d"
   name = "github.com/AlecAivazis/survey"
   packages = ["."]
   pruneopts = "UT"
@@ -35,7 +35,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:45a787c1adea69a03a5384865b307c7a72bb28bd5844bd57679d889a726a588b"
+  digest = "1:315c5f2f60c76d89b871c73f9bd5fe689cad96597afd50fb9992228ef80bdd34"
   name = "github.com/alecthomas/template"
   packages = [
     ".",
@@ -61,7 +61,7 @@
   version = "v1.0.0"
 
 [[projects]]
-  digest = "1:572a558f325deb4f667adda03a0242c4e98a20ddb47b22a89f2b2ba8ddf7aeae"
+  digest = "1:10cdb19adf265e8deb8e62b02e7a8c81117a214fded00d2a07c75c8bb2a02542"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -144,6 +144,21 @@
   version = "v1.37.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:34cb7d19f5610289f8f9ed202b2bfeaa37390308d59ac5fd6cb82bd187e663b1"
+  name = "github.com/headzoo/surf"
+  packages = [
+    ".",
+    "agent",
+    "browser",
+    "errors",
+    "jar",
+    "util",
+  ]
+  pruneopts = "UT"
+  revision = "a4a8c16c01dc47ef3a25326d21745806f3e6797a"
+
+[[projects]]
   digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
@@ -199,6 +214,22 @@
   version = "v1.0.0"
 
 [[projects]]
+  branch = "master"
+  digest = "1:dbfe572cc258e5bcf54cb650a06d90edd0da04e42ca1ed909cc1d49f00011c63"
+  name = "github.com/robertkrimen/otto"
+  packages = [
+    ".",
+    "ast",
+    "dbg",
+    "file",
+    "parser",
+    "registry",
+    "token",
+  ]
+  pruneopts = "UT"
+  revision = "15f95af6e78dcd2030d8195a138bd88d4f403546"
+
+[[projects]]
   digest = "1:9e9193aa51197513b3abcb108970d831fbcf40ef96aa845c4f03276e1fa316d2"
   name = "github.com/sirupsen/logrus"
   packages = ["."]
@@ -215,7 +246,7 @@
   version = "v0.1.1"
 
 [[projects]]
-  digest = "1:0ce644ed4e959cb140cb8ece625650cdad11499671a00f5878ccd0c38c334010"
+  digest = "1:cf4fdb98e23a565bd82473027d37512a3d5b186fba3a1895d7e8401d8ce3ffe1"
   name = "github.com/stretchr/testify"
   packages = [
     "assert",
@@ -244,7 +275,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:0db47756e69b5d1749fbfc501974538c6885bb9593b62c54736c9de035dbe057"
+  digest = "1:ee04668811bcca0958f730d2595813a8d2561e9a9e68b0387de6362545d9823b"
   name = "golang.org/x/crypto"
   packages = [
     "md4",
@@ -255,7 +286,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:d4c427db92c1d8c0df6c3ba45ce63c10d967dbb31d8bf5a87e16f1714ae370d2"
+  digest = "1:aa1b5903bc0257d88515fdf5025bf42c689605bdf92c249e0c557accdd3652cd"
   name = "golang.org/x/net"
   packages = [
     "html",
@@ -268,7 +299,7 @@
 
 [[projects]]
   branch = "master"
-  digest = "1:63c79e21224f8c86558234dbadf41df6cd77d9312dc60326129200b84e32d1d6"
+  digest = "1:0d0ca6aa81eb65a52a6e128bddf01753daed51c82550ddd9db9822b272f69f72"
   name = "golang.org/x/sys"
   packages = [
     "unix",
@@ -278,7 +309,7 @@
   revision = "8014b7b116a67fea23fbb82cd834c9ad656ea44b"
 
 [[projects]]
-  digest = "1:7509ba4347d1f8de6ae9be8818b0cd1abc3deeffe28aeaf4be6d4b6b5178d9ca"
+  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -301,7 +332,7 @@
   version = "v0.3.0"
 
 [[projects]]
-  digest = "1:7a08a75e5e4fad22b3377922414fbb3449a4a7c868f9da41e8acb2daac40497d"
+  digest = "1:7849dff11be3defef1f33a9e469329f8786afb4649d115d7b2027717fe4eb4eb"
   name = "gopkg.in/AlecAivazis/survey.v1"
   packages = [
     "core",
@@ -319,6 +350,17 @@
   revision = "06f5f3d67269ccec1fe5fe4134ba6e982984f7f5"
   version = "v1.37.0"
 
+[[projects]]
+  digest = "1:9935525a8c49b8434a0b0a54e1980e94a6fae73aaff45c5d33ba8dff69de123e"
+  name = "gopkg.in/sourcemap.v1"
+  packages = [
+    ".",
+    "base64vlq",
+  ]
+  pruneopts = "UT"
+  revision = "6e83acea0053641eff084973fee085f0c193c61a"
+  version = "v1.0.5"
+
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
@@ -334,8 +376,11 @@
     "github.com/beevik/etree",
     "github.com/briandowns/spinner",
     "github.com/danieljoos/wincred",
+    "github.com/headzoo/surf",
+    "github.com/headzoo/surf/browser",
     "github.com/mitchellh/go-homedir",
     "github.com/pkg/errors",
+    "github.com/robertkrimen/otto",
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/mock",

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -84,3 +84,7 @@
 [prune]
   go-tests = true
   unused-packages = true
+
+[[constraint]]
+  branch = "master"
+  name = "github.com/headzoo/surf"

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -46,12 +46,12 @@ func main() {
 
 	// Settings not related to commands
 	verbose := app.Flag("verbose", "Enable verbose logging").Bool()
-	provider := app.Flag("provider", "This flag it is obsolete see https://github.com/Versent/saml2aws#adding-idp-accounts.").Short('i').Enum("ADFS", "ADFS2", "Ping", "JumpCloud", "Okta", "OneLogin", "KeyCloak")
+	provider := app.Flag("provider", "This flag it is obsolete see https://github.com/Versent/saml2aws#adding-idp-accounts.").Short('i').Enum("ADFS", "ADFS2", "Ping", "JumpCloud", "Okta", "OneLogin", "PSU", "KeyCloak")
 
 	// Common (to all commands) settings
 	commonFlags := new(flags.CommonFlags)
 	app.Flag("idp-account", "The name of the configured IDP account").Short('a').Default("default").StringVar(&commonFlags.IdpAccount)
-	app.Flag("idp-provider", "The configured IDP provider").EnumVar(&commonFlags.IdpProvider, "ADFS", "ADFS2", "Ping", "JumpCloud", "Okta", "OneLogin", "KeyCloak")
+	app.Flag("idp-provider", "The configured IDP provider").EnumVar(&commonFlags.IdpProvider, "ADFS", "ADFS2", "Ping", "JumpCloud", "Okta", "OneLogin", "PSU", "KeyCloak")
 	app.Flag("mfa", "The name of the mfa").StringVar(&commonFlags.MFA)
 	app.Flag("skip-verify", "Skip verification of server certificate.").Short('s').BoolVar(&commonFlags.SkipVerify)
 	app.Flag("url", "The URL of the SAML IDP server used to login.").StringVar(&commonFlags.URL)

--- a/pkg/provider/psu/README.md
+++ b/pkg/provider/psu/README.md
@@ -1,0 +1,21 @@
+# PSU provider
+
+This provider authenticates via Penn State University's Cosign+Shibboleth
+implementation, then handles the typical WebAccess 2FA multi-factor
+authentication using either Duo or YubiKeys.
+
+## Instructions
+
+Uses default Shibboleth 3.3 pathing for the entry point.  e.g. if url is
+"https://idp.example.com" and the AWS URN is left as the default, this will
+construct the following URL to use.
+`https://idp.example.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:webservices`
+
+To configure for PSU Access Shibboleth, run `saml2aws configure`, select PSU as
+the provider, and enter `https://as1.fim.psu.edu` for URL. Username is
+optional.
+
+## Features
+
+* Prompts for Duo MFA when logging in. Options are Duo Push, Phone Call, and
+  Passcode. Similar to the Duo SSH integration.

--- a/pkg/provider/psu/psu.go
+++ b/pkg/provider/psu/psu.go
@@ -1,0 +1,261 @@
+package psu
+
+import (
+	"encoding/json"
+	"fmt"
+	"github.com/headzoo/surf"
+	"github.com/headzoo/surf/browser"
+	"github.com/pkg/errors"
+	"github.com/robertkrimen/otto"
+	"github.com/sirupsen/logrus"
+	"github.com/versent/saml2aws/pkg/cfg"
+	"github.com/versent/saml2aws/pkg/creds"
+	"github.com/versent/saml2aws/pkg/prompter"
+	"github.com/versent/saml2aws/pkg/provider"
+	"regexp"
+	"strconv"
+	"time"
+)
+
+var logger = logrus.WithField("provider", "psu")
+
+// Client contains our browser and IDP Account configuration
+type Client struct {
+	b  *browser.Browser
+	ia *cfg.IDPAccount
+}
+
+// duoResults contains the extracted duoResults JS object from the 2FA page
+type duoResults struct {
+	AccountType string `json:"account_type"`
+	Devices     struct {
+		Devices []duoDevice `json:"devices"`
+	} `json:"devices"`
+	Error            string `json:"error"`
+	Referrer         string `json:"referrer"`
+	Remoteuser       string `json:"remoteuser"`
+	RequiredFactors  string `json:"requiredFactors"`
+	SatisfiedFactors string `json:"satisfiedFactors"`
+	Service          string `json:"service"`
+}
+
+// duoDevice describes a Duo 2FA device, its capabilities, etc
+// This is very similar to https://godoc.org/github.com/duosecurity/duo_api_golang/authapi#PreauthResult
+// but augmented for our purposes
+type duoDevice struct {
+	Capabilities []string `json:"capabilities"`
+	Device       string   `json:"device"`
+	DisplayName  string   `json:"display_name"`
+	SmsNextcode  string   `json:"sms_nextcode,omitempty"`
+	Type         string   `json:"type"`
+	OptionType   string   `json:"omitempty"`
+	Prompt       string   `json:"omitempty"`
+}
+
+// New returns a new psu.Client with the browser and idp account instantiated
+func New(idpAccount *cfg.IDPAccount) (*Client, error) {
+
+	tr := provider.NewDefaultTransport(idpAccount.SkipVerify)
+
+	// create our browser
+	b := surf.NewBrowser()
+	b.SetTimeout(time.Duration(idpAccount.Timeout) * time.Second)
+	b.SetTransport(tr)
+
+	return &Client{
+		b:  b,
+		ia: idpAccount,
+	}, nil
+}
+
+// Authenticate authenticates to PSU
+func (pc *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error) {
+
+	assertion, err := pc.login(loginDetails)
+
+	return assertion, err
+}
+
+func (pc *Client) login(loginDetails *creds.LoginDetails) (string, error) {
+	// Send our request to the IdP, which will redirect us to WebAccess
+	requestURL := fmt.Sprintf("%s/idp/profile/SAML2/Unsolicited/SSO?providerId=%s", loginDetails.URL, pc.ia.AmazonWebservicesURN)
+	logger.Debugf("Sending request to IdP: %s\n", requestURL)
+	err := pc.b.Open(requestURL)
+	if err != nil {
+		return "", errors.Wrapf(err, "Requesting initial IDP URL (%s)", requestURL)
+	}
+
+	logger.Debugf("Current URL: %s\n", pc.b.Url())
+
+	// find our login form
+	fm, err := pc.b.Form("form")
+	if err != nil {
+		return "", errors.Wrapf(err, "Unable to find login form on %s", pc.b.Url())
+	}
+
+	// submit username/password
+	logger.Debugf("Submitting creds to: %s\n", fm.Action())
+
+	err = fm.Input("login", loginDetails.Username)
+	if err != nil {
+		return "", errors.Wrap(err, "Could not find login input field")
+	}
+
+	err = fm.Input("password", loginDetails.Password)
+	if err != nil {
+		return "", errors.Wrap(err, "Could not find password input field")
+	}
+
+	err = fm.Submit()
+	if err != nil {
+		return "", errors.Wrapf(err, "Error when submitting creds to %s", fm.Action())
+	}
+
+	// find the 2fa form to make sure we are logged in before going any further
+	fm, err = pc.b.Form("form")
+	if err != nil {
+		return "", errors.Wrapf(err, "Could not locate 2FA form on %s, perhaps the login failed?", pc.b.Url())
+	}
+
+	// extract duoResults object from body text
+	dr, err := extractDuoResults(pc.b.Body())
+	if err != nil {
+		return "", errors.Wrapf(err, "Calling extractDuoResults() on 2FA login page body")
+	}
+
+	// parse duoResults into devices
+	duoDevices := parseDuoResults(dr)
+
+	// present list of duo options and prompt for input
+	fmt.Print("Enter a passcode or select one of the following options:\n\n")
+	for i, d := range duoDevices {
+		fmt.Printf(" %d. %s\n", i, d.Prompt)
+	}
+
+	fmt.Println() // get an extra space between options and input prompt
+
+	option := prompter.StringRequired("Passcode or option")
+	optint, err := strconv.Atoi(option) // try to convert input to int to partially validate it
+	if err != nil {
+		return "", errors.Wrapf(err, "Failed to convert %v to int", option)
+	}
+
+	// fill out 2FA form
+	if optint > len(duoDevices) {
+		// selection is larger than the number of options, assume it is a passcode
+		err = fm.Set("duo_passcode", option)
+		if err != nil {
+			return "", errors.Wrap(err, "Setting duo_passcode form field")
+		}
+
+		err = fm.Set("duo_factor", "passcode")
+		if err != nil {
+			return "", errors.Wrap(err, "Setting duo_factor form field")
+		}
+	} else {
+		// otherwise, set device and factor
+		err = fm.Input("duo_device", duoDevices[optint].Device)
+		if err != nil {
+			return "", errors.Wrap(err, "Setting duo_device form field")
+		}
+
+		err = fm.Set("duo_factor", duoDevices[optint].OptionType)
+		if err != nil {
+			return "", errors.Wrap(err, "Setting duo_factor form field")
+		}
+	}
+
+	// submit form
+	err = fm.Submit()
+	if err != nil {
+		return "", errors.Wrap(err, "Error when submitting form")
+	}
+
+	// pull the assertion out of the response
+	doc := pc.b.Dom()
+	s := doc.Find("input[name=SAMLResponse]").First()
+	assertion, ok := s.Attr("value")
+	if !ok {
+		return "", fmt.Errorf("Response from %s did not provide a SAML assertion (SAMLResponse html element)", pc.b.Url())
+	}
+	return assertion, nil
+}
+
+func stringInSlice(a string, list []string) bool {
+	for _, b := range list {
+		if b == a {
+			return true
+		}
+	}
+	return false
+}
+
+// build list of devices and options for the user prompt
+// it's simpler to do this in one block
+func parseDuoResults(dr duoResults) (devices []duoDevice) {
+	i := 0
+	for _, t := range []string{"push", "phone", "sms"} {
+		for _, d := range dr.Devices.Devices {
+			if stringInSlice(t, d.Capabilities) {
+				devices = append(devices, d)
+				devices[i].OptionType = t
+				switch t {
+				case "push":
+					devices[i].Prompt = fmt.Sprintf("Duo Push to %s", d.DisplayName)
+				case "phone":
+					devices[i].Prompt = fmt.Sprintf("Phone call to %s", d.DisplayName)
+				case "sms":
+					nextcode := ""
+					if d.SmsNextcode != "" {
+						nextcode = fmt.Sprintf(" (next code starts with %s)", d.SmsNextcode)
+					}
+					devices[i].Prompt = fmt.Sprintf("SMS passcodes to %s%s", d.DisplayName, nextcode)
+				}
+				i++
+			}
+		}
+	}
+	return
+}
+
+// extract duoResults from a body of text
+func extractDuoResults(body string) (dr duoResults, err error) {
+	// extract duoResults text from body
+	re := regexp.MustCompile(`var\s+duoResults\s+=\s+({[\S\s]*});`)
+	matches := re.FindStringSubmatch(body)
+	if len(matches) != 2 {
+		return dr, errors.New("Something went wrong, duoResults variable not present on page after submitting login")
+	}
+
+	// Create new JavaScript VM with a single variable called input, with our JS object assigned
+	vm := otto.New()
+	err = vm.Set("input", matches[1])
+	if err != nil {
+		return dr, errors.Wrap(err, "Setting JS VM input value")
+	}
+
+	// Call JavaScript's JSON.stringify() on the input variable we Set() above
+	stringifyOutput, err := vm.Run(`JSON.stringify( eval('('+input+')') )`)
+	if err != nil {
+		return dr, errors.Wrapf(err, "JSON.stringify returned `%s` when trying to extract Duo result JSON object", err)
+	}
+
+	// call otto's .ToString() on duoResultsJSON to turn it from a ott.Value to a string
+	duoResultsJSON, err := stringifyOutput.ToString()
+	if err != nil {
+		return dr, errors.Wrap(err, "ToString()")
+	}
+
+	// unmarshal JSON byte object into a duoResults struct
+	err = json.Unmarshal([]byte(duoResultsJSON), &dr)
+	if err != nil {
+		return dr, errors.Wrap(err, "Calling json.Unmarshal on duoResultsJSON")
+	}
+
+	// check that we didn't get a 0-length result
+	if len(dr.Devices.Devices) == 0 {
+		return dr, errors.New("No 2FA devices returned")
+	}
+
+	return
+}

--- a/pkg/provider/psu/psu_test.go
+++ b/pkg/provider/psu/psu_test.go
@@ -1,0 +1,79 @@
+package psu
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+var goodDuoResults = `<script type="text/javascript">var duoResults = {
+      devices: {"devices":[{"capabilities":["push","phone","sms"],"device":"abcdefg123456789","display_name":"Phone 1 (XXX-XXX-1234)","sms_nextcode":"1","type":"phone"},{"capabilities":["phone","sms"],"device":"987654321gfedcba","display_name":"Phone 2 (XXX-XXX-5678)","type":"phone"},{"capabilities":[],"device":"hijklmnop123456789","display_name":"12345678","type":"token"}]},
+      service: 'cosign-as1.fim.psu.edu',
+      referrer: 'https://as1.fim.psu.edu/idp/Authn/RemoteUser?conversation=e1s1',
+      remoteuser: '',
+      account_type: "dce",
+      requiredFactors: unescape('dce.psu.edu,2fa'),
+      satisfiedFactors: 'dce.psu.edu',
+      error: 'Additional authentication is required.',
+      onRedirect: function(url) {
+        window.location.assign(url);
+      }
+    };
+</script>`
+
+func TestStringInSlice(t *testing.T) {
+	needle := "needle"
+	haystackA := []string{"foo", "bar", "baz", "needle"}
+	haystackB := []string{"foo", "bar", "baz"}
+
+	assert.True(t, stringInSlice(needle, haystackA), "is true")
+	assert.False(t, stringInSlice(needle, haystackB), "is false")
+}
+
+func TestExtractDuoResults(t *testing.T) {
+
+	r, err := extractDuoResults(goodDuoResults)
+	assert.NoError(t, err)
+	assert.Len(t, r.Devices.Devices, 3)
+
+	_, err = extractDuoResults("")
+	assert.Error(t, err)
+
+	_, err = extractDuoResults(`var thisIsValidJson = {foo: "bar"};`)
+	assert.Error(t, err)
+
+	_, err = extractDuoResults(`var duoResults = {foo: "bar"};`)
+	assert.Error(t, err)
+
+	r, err = extractDuoResults(`var duoResults = { devices: {"devices":[]} };`)
+	assert.Error(t, err)
+	assert.Len(t, r.Devices.Devices, 0)
+}
+
+func TestParseDuoResults(t *testing.T) {
+
+	dr, err := extractDuoResults(goodDuoResults)
+	assert.Nil(t, err)
+
+	duoDevices := parseDuoResults(dr)
+	assert.Len(t, duoDevices, 5)
+
+	// push
+	assert.Equal(t, "push", duoDevices[0].OptionType)
+	assert.Equal(t, "abcdefg123456789", duoDevices[0].Device)
+	assert.Equal(t, "Duo Push to Phone 1 (XXX-XXX-1234)", duoDevices[0].Prompt)
+
+	// phone
+	assert.Equal(t, "phone", duoDevices[1].OptionType)
+	assert.Equal(t, "abcdefg123456789", duoDevices[1].Device)
+	assert.Equal(t, "Phone call to Phone 1 (XXX-XXX-1234)", duoDevices[1].Prompt)
+
+	// sms with next code
+	assert.Equal(t, "sms", duoDevices[3].OptionType, "sms")
+	assert.Equal(t, "abcdefg123456789", duoDevices[3].Device)
+	assert.Equal(t, "SMS passcodes to Phone 1 (XXX-XXX-1234) (next code starts with 1)", duoDevices[3].Prompt)
+
+	// sms without next code
+	assert.Equal(t, "sms", duoDevices[4].OptionType, "sms")
+	assert.Equal(t, "987654321gfedcba", duoDevices[4].Device)
+	assert.Equal(t, "SMS passcodes to Phone 2 (XXX-XXX-5678)", duoDevices[4].Prompt)
+}

--- a/saml2aws.go
+++ b/saml2aws.go
@@ -15,6 +15,7 @@ import (
 	"github.com/versent/saml2aws/pkg/provider/onelogin"
 	"github.com/versent/saml2aws/pkg/provider/pingfed"
 	"github.com/versent/saml2aws/pkg/provider/pingone"
+	"github.com/versent/saml2aws/pkg/provider/psu"
 	"github.com/versent/saml2aws/pkg/provider/shibboleth"
 )
 
@@ -33,6 +34,7 @@ var MFAsByProvider = ProviderList{
 	"KeyCloak":   []string{"Auto"},                                       // automatically detects ToTP
 	"GoogleApps": []string{"Auto"},                                       // automatically detects ToTP
 	"Shibboleth": []string{"Auto"},
+	"PSU":        []string{"Auto"},
 }
 
 // Names get a list of provider names
@@ -128,6 +130,11 @@ func NewSAMLClient(idpAccount *cfg.IDPAccount) (SAMLClient, error) {
 			return nil, fmt.Errorf("Invalid MFA type: %v for %v provider", idpAccount.MFA, idpAccount.Provider)
 		}
 		return shibboleth.New(idpAccount)
+	case "PSU":
+		if invalidMFA(idpAccount.Provider, idpAccount.MFA) {
+			return nil, fmt.Errorf("Invalid MFA type: %v for %v provider", idpAccount.MFA, idpAccount.Provider)
+		}
+		return psu.New(idpAccount)
 	default:
 		return nil, fmt.Errorf("Invalid provider: %v", idpAccount.Provider)
 	}

--- a/saml2aws_test.go
+++ b/saml2aws_test.go
@@ -10,7 +10,7 @@ func TestProviderList_Keys(t *testing.T) {
 
 	names := MFAsByProvider.Names()
 
-	require.Len(t, names, 10)
+	require.Len(t, names, 11)
 
 }
 


### PR DESCRIPTION
I wanted to start a discussion around adding a somewhat custom provider to saml2aws. Penn State University has a somewhat customized implementation of Shibboleth+Cosign that prevents us from using the existing shibboleth provider.

I originally went down the road of building our own [tool](https://github.com/acobaugh/psu-saml-aws-login), then discovered saml2aws when researching methods of manipulating the user's AWS profile. This provider is effectively a straight import of the code from my own tool.

Notably, this provider:
* Uses https://github.com/headzoo/surf for web scraping. This is effectively a wrapper around goquery. I could change this to use goquery directly, but it would make the code more complicated
* Has some fmt.Print*'s to allow customizing the output format of some of the prompts, but still uses `prompter` to gather the actual input

I'm willing to change/squash/refactor whatever is necessary if the project owners are willing to accept this PR (I know I have an errant `go fmt` in the commit list, which I can pull out if desired). If not, perhaps we can have a discussion around making the providers more pluggable a-la terraform (whose providers are standalone binaries that the user can drop-in and customize). In the end, I want to be able to take advantage of the framework the saml2aws already provides.