### PR TITLE
Add environment variable support to more flags

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,29 +92,37 @@ Flags:
                                and --help-man).
       --version                Show application version.
       --verbose                Enable verbose logging
-  -i, --provider=PROVIDER      This flag it is obsolete see
-                               https://github.com/Versent/saml2aws#adding-idp-accounts.
-  -a, --idp-account="default"  The name of the configured IDP account
-      --idp-provider=IDP-PROVIDER
-                               The configured IDP provider
-      --mfa=MFA                The name of the mfa
+  -i, --provider=PROVIDER      This flag is obsolete. See:
+                               https://github.com/Versent/saml2aws#configuring-idp-accounts
+  -a, --idp-account="default"  The name of the configured IDP account. (env:
+                               SAML2AWS_IDP_ACCOUNT)
+      --idp-provider=IDP-PROVIDER  
+                               The configured IDP provider. (env:
+                               SAML2AWS_IDP_PROVIDER)
+      --mfa=MFA                The name of the mfa. (env: SAML2AWS_MFA)
   -s, --skip-verify            Skip verification of server certificate.
       --url=URL                The URL of the SAML IDP server used to login.
-      --username=USERNAME      The username used to login.
-      --password=PASSWORD      The password used to login.
+                               (env: SAML2AWS_URL)
+      --username=USERNAME      The username used to login. (env:
+                               SAML2AWS_USERNAME)
+      --password=PASSWORD      The password used to login. (env:
+                               SAML2AWS_PASSWORD)
       --mfa-token=MFA-TOKEN    The current MFA token (supported in Keycloak,
-                               ADFS).
-      --role=ROLE              The ARN of the role to assume.
-      --aws-urn=AWS-URN        The URN used by SAML when you login.
+                               ADFS). (env: SAML2AWS_MFA_TOKEN)
+      --role=ROLE              The ARN of the role to assume. (env:
+                               SAML2AWS_ROLE)
+      --aws-urn=AWS-URN        The URN used by SAML when you login. (env:
+                               SAML2AWS_AWS_URN)
       --skip-prompt            Skip prompting for parameters during login.
-      --session-duration=SESSION-DURATION
-                               The duration of your AWS Session.
+      --session-duration=SESSION-DURATION  
+                               The duration of your AWS Session. (env:
+                               SAML2AWS_SESSION_DURATION)
 
 Commands:
   help [<command>...]
     Show help.
 
-  configure
+  configure [<flags>]
     Configure a new IDP account.
 
   login [<flags>]
@@ -127,7 +135,7 @@ Commands:
     List available role ARNs.
 
   script [<flags>]
-    Script will emit a script that will export environment variables
+    Emit a script that will export environment variables.
 ```
 
 

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -46,43 +46,43 @@ func main() {
 
 	// Settings not related to commands
 	verbose := app.Flag("verbose", "Enable verbose logging").Bool()
-	provider := app.Flag("provider", "This flag it is obsolete see https://github.com/Versent/saml2aws#adding-idp-accounts.").Short('i').Enum("ADFS", "ADFS2", "Ping", "JumpCloud", "Okta", "OneLogin", "PSU", "KeyCloak")
+	provider := app.Flag("provider", "This flag is obsolete. See: https://github.com/Versent/saml2aws#configuring-idp-accounts").Short('i').Enum("ADFS", "ADFS2", "Ping", "JumpCloud", "Okta", "OneLogin", "PSU", "KeyCloak")
 
 	// Common (to all commands) settings
 	commonFlags := new(flags.CommonFlags)
-	app.Flag("idp-account", "The name of the configured IDP account").Short('a').Default("default").StringVar(&commonFlags.IdpAccount)
-	app.Flag("idp-provider", "The configured IDP provider").EnumVar(&commonFlags.IdpProvider, "ADFS", "ADFS2", "Ping", "JumpCloud", "Okta", "OneLogin", "PSU", "KeyCloak")
-	app.Flag("mfa", "The name of the mfa").StringVar(&commonFlags.MFA)
+	app.Flag("idp-account", "The name of the configured IDP account. (env: SAML2AWS_IDP_ACCOUNT)").Envar("SAML2AWS_IDP_ACCOUNT").Short('a').Default("default").StringVar(&commonFlags.IdpAccount)
+	app.Flag("idp-provider", "The configured IDP provider. (env: SAML2AWS_IDP_PROVIDER)").Envar("SAML2AWS_IDP_PROVIDER").EnumVar(&commonFlags.IdpProvider, "ADFS", "ADFS2", "Ping", "JumpCloud", "Okta", "OneLogin", "PSU", "KeyCloak")
+	app.Flag("mfa", "The name of the mfa. (env: SAML2AWS_MFA)").Envar("SAML2AWS_MFA").StringVar(&commonFlags.MFA)
 	app.Flag("skip-verify", "Skip verification of server certificate.").Short('s').BoolVar(&commonFlags.SkipVerify)
-	app.Flag("url", "The URL of the SAML IDP server used to login.").StringVar(&commonFlags.URL)
-	app.Flag("username", "The username used to login.").Envar("SAML2AWS_USERNAME").StringVar(&commonFlags.Username)
-	app.Flag("password", "The password used to login.").Envar("SAML2AWS_PASSWORD").StringVar(&commonFlags.Password)
-	app.Flag("mfa-token", "The current MFA token (supported in Keycloak, ADFS).").Envar("SAML2AWS_MFA_TOKEN").StringVar(&commonFlags.MFAToken)
-	app.Flag("role", "The ARN of the role to assume.").StringVar(&commonFlags.RoleArn)
-	app.Flag("aws-urn", "The URN used by SAML when you login.").StringVar(&commonFlags.AmazonWebservicesURN)
+	app.Flag("url", "The URL of the SAML IDP server used to login. (env: SAML2AWS_URL)").Envar("SAML2AWS_URL").StringVar(&commonFlags.URL)
+	app.Flag("username", "The username used to login. (env: SAML2AWS_USERNAME)").Envar("SAML2AWS_USERNAME").StringVar(&commonFlags.Username)
+	app.Flag("password", "The password used to login. (env: SAML2AWS_PASSWORD)").Envar("SAML2AWS_PASSWORD").StringVar(&commonFlags.Password)
+	app.Flag("mfa-token", "The current MFA token (supported in Keycloak, ADFS). (env: SAML2AWS_MFA_TOKEN)").Envar("SAML2AWS_MFA_TOKEN").StringVar(&commonFlags.MFAToken)
+	app.Flag("role", "The ARN of the role to assume. (env: SAML2AWS_ROLE)").Envar("SAML2AWS_ROLE").StringVar(&commonFlags.RoleArn)
+	app.Flag("aws-urn", "The URN used by SAML when you login. (env: SAML2AWS_AWS_URN)").Envar("SAML2AWS_AWS_URN").StringVar(&commonFlags.AmazonWebservicesURN)
 	app.Flag("skip-prompt", "Skip prompting for parameters during login.").BoolVar(&commonFlags.SkipPrompt)
-	app.Flag("session-duration", "The duration of your AWS Session.").IntVar(&commonFlags.SessionDuration)
+	app.Flag("session-duration", "The duration of your AWS Session. (env: SAML2AWS_SESSION_DURATION)").Envar("SAML2AWS_SESSION_DURATION").IntVar(&commonFlags.SessionDuration)
 
 	// `configure` command and settings
 	cmdConfigure := app.Command("configure", "Configure a new IDP account.")
-	cmdConfigure.Flag("app-id", "OneLogin app id required for SAML assertion.").Envar("ONELOGIN_APP_ID").StringVar(&commonFlags.AppID)
-	cmdConfigure.Flag("client-id", "OneLogin client id, used to generate API access token.").Envar("ONELOGIN_CLIENT_ID").StringVar(&commonFlags.ClientID)
-	cmdConfigure.Flag("client-secret", "OneLogin client secret, used to generate API access token.").Envar("ONELOGIN_CLIENT_SECRET").StringVar(&commonFlags.ClientSecret)
-	cmdConfigure.Flag("subdomain", "OneLogin subdomain of your company account.").Envar("ONELOGIN_SUBDOMAIN").StringVar(&commonFlags.Subdomain)
+	cmdConfigure.Flag("app-id", "OneLogin app id required for SAML assertion. (env: ONELOGIN_APP_ID)").Envar("ONELOGIN_APP_ID").StringVar(&commonFlags.AppID)
+	cmdConfigure.Flag("client-id", "OneLogin client id, used to generate API access token. (env: ONELOGIN_CLIENT_ID)").Envar("ONELOGIN_CLIENT_ID").StringVar(&commonFlags.ClientID)
+	cmdConfigure.Flag("client-secret", "OneLogin client secret, used to generate API access token. (env: ONELOGIN_CLIENT_SECRET)").Envar("ONELOGIN_CLIENT_SECRET").StringVar(&commonFlags.ClientSecret)
+	cmdConfigure.Flag("subdomain", "OneLogin subdomain of your company account. (env: ONELOGIN_SUBDOMAIN)").Envar("ONELOGIN_SUBDOMAIN").StringVar(&commonFlags.Subdomain)
 	configFlags := commonFlags
 
 	// `login` command and settings
 	cmdLogin := app.Command("login", "Login to a SAML 2.0 IDP and convert the SAML assertion to an STS token.")
 	loginFlags := new(flags.LoginExecFlags)
 	loginFlags.CommonFlags = commonFlags
-	cmdLogin.Flag("profile", "The AWS profile to save the temporary credentials").Short('p').StringVar(&commonFlags.Profile)
-	cmdLogin.Flag("force", "Refreshes credentials even if not expired").BoolVar(&loginFlags.Force)
+	cmdLogin.Flag("profile", "The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)").Short('p').Envar("SAML2AWS_PROFILE").StringVar(&commonFlags.Profile)
+	cmdLogin.Flag("force", "Refresh credentials even if not expired.").BoolVar(&loginFlags.Force)
 
 	// `exec` command and settings
 	cmdExec := app.Command("exec", "Exec the supplied command with env vars from STS token.")
 	execFlags := new(flags.LoginExecFlags)
 	execFlags.CommonFlags = commonFlags
-	cmdExec.Flag("profile", "The AWS profile to save the temporary credentials").Short('p').StringVar(&commonFlags.Profile)
+	cmdExec.Flag("profile", "The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)").Envar("SAML2AWS_PROFILE").Short('p').StringVar(&commonFlags.Profile)
 	cmdLine := buildCmdList(cmdExec.Arg("command", "The command to execute."))
 
 	// `list` command and settings
@@ -91,13 +91,13 @@ func main() {
 	listRolesFlags.CommonFlags = commonFlags
 
 	// `script` command and settings
-	cmdScript := app.Command("script", "Script will emit a script that will export environment variables")
+	cmdScript := app.Command("script", "Emit a script that will export environment variables.")
 	scriptFlags := new(flags.LoginExecFlags)
 	scriptFlags.CommonFlags = commonFlags
-	cmdScript.Flag("profile", "The AWS profile to save the temporary credentials").Short('p').StringVar(&commonFlags.Profile)
+	cmdScript.Flag("profile", "The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)").Envar("SAML2AWS_PROFILE").Short('p').StringVar(&commonFlags.Profile)
 	var shell string
 	cmdScript.
-		Flag("shell", "Type of shell environment, options include: bash, powershell, fish").
+		Flag("shell", "Type of shell environment. Options include: bash, powershell, fish").
 		Default("bash").
 		EnumVar(&shell, "bash", "powershell", "fish")
 


### PR DESCRIPTION
To support a direnv-style project where multiple IDPs or roles may need to be used, add `.Envar` to more flags. Also add the environment variables to help output and perform some minor housekeeping on the help output text.

This also updates the link in the help output, identified in #251 as being broken.