### PR TITLE
Add a configurable option to set the duo mfa option

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,23 +16,7 @@ The process goes something like this:
 
 ## Table of Contents
 
-<!-- TOC depthFrom:2 -->
-
-- [Table of Contents](#table-of-contents)
-- [Requirements](#requirements)
-- [Caveats](#caveats)
-- [Install](#install)
-    - [OSX](#osx)
-    - [Windows](#windows)
-- [Dependency Setup](#dependency-setup)
-- [Usage](#usage)
-    - [`saml2aws script`](#saml2aws-script)
-    - [Configuring IDP Accounts](#configuring-idp-accounts)
-- [Example](#example)
-- [Building](#building)
-- [Environment vars](#environment-vars)
-
-<!-- /TOC -->
+<!-- TOC depthFrom:2 -->autoauto- [Table of Contents](#table-of-contents)auto- [Requirements](#requirements)auto- [Caveats](#caveats)auto- [Install](#install)auto    - [OSX](#osx)auto    - [Windows](#windows)auto- [Dependency Setup](#dependency-setup)auto- [Usage](#usage)auto    - [`saml2aws script`](#saml2aws-script)auto    - [Configuring IDP Accounts](#configuring-idp-accounts)auto- [Example](#example)auto- [Building](#building)auto- [Environment vars](#environment-vars)autoauto<!-- /TOC -->
 
 ## Requirements
 
@@ -97,7 +81,7 @@ Flags:
                                https://github.com/Versent/saml2aws#configuring-idp-accounts
   -a, --idp-account="default"  The name of the configured IDP account. (env:
                                SAML2AWS_IDP_ACCOUNT)
-      --idp-provider=IDP-PROVIDER  
+      --idp-provider=IDP-PROVIDER
                                The configured IDP provider. (env:
                                SAML2AWS_IDP_PROVIDER)
       --mfa=MFA                The name of the mfa. (env: SAML2AWS_MFA)
@@ -114,8 +98,9 @@ Flags:
                                SAML2AWS_ROLE)
       --aws-urn=AWS-URN        The URN used by SAML when you login. (env:
                                SAML2AWS_AWS_URN)
+      --duo-mfa-option         The MFA option you want to use to authenticate (env: SAML_DUO_MFA_OPTION)
       --skip-prompt            Skip prompting for parameters during login.
-      --session-duration=SESSION-DURATION  
+      --session-duration=SESSION-DURATION
                                The duration of your AWS Session. (env:
                                SAML2AWS_SESSION_DURATION)
 

--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -129,7 +129,7 @@ func resolveLoginDetails(account *cfg.IDPAccount, loginFlags *flags.LoginExecFla
 
 	// fmt.Printf("loginFlags %+v\n", loginFlags)
 
-	loginDetails := &creds.LoginDetails{URL: account.URL, Username: account.Username, MFAToken: loginFlags.CommonFlags.MFAToken}
+	loginDetails := &creds.LoginDetails{URL: account.URL, Username: account.Username, MFAToken: loginFlags.CommonFlags.MFAToken, DuoMFAOption: loginFlags.DuoMFAOption}
 
 	fmt.Printf("Using IDP Account %s to access %s %s\n", loginFlags.CommonFlags.IdpAccount, account.Provider, account.URL)
 

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -76,6 +76,7 @@ func main() {
 	loginFlags := new(flags.LoginExecFlags)
 	loginFlags.CommonFlags = commonFlags
 	cmdLogin.Flag("profile", "The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)").Short('p').Envar("SAML2AWS_PROFILE").StringVar(&commonFlags.Profile)
+	cmdLogin.Flag("duo-mfa-option", "The MFA option you want to use to authenticate with").Envar("SAML2AWS_DUO_MFA_OPTION").EnumVar(&loginFlags.DuoMFAOption, "Passcode", "Duo Push")
 	cmdLogin.Flag("force", "Refresh credentials even if not expired.").BoolVar(&loginFlags.Force)
 
 	// `exec` command and settings

--- a/pkg/creds/creds.go
+++ b/pkg/creds/creds.go
@@ -9,6 +9,7 @@ type LoginDetails struct {
 	Username     string
 	Password     string
 	MFAToken     string
+	DuoMFAOption string
 	URL          string
 }
 

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -27,8 +27,9 @@ type CommonFlags struct {
 
 // LoginExecFlags flags for the Login / Exec commands
 type LoginExecFlags struct {
-	CommonFlags *CommonFlags
-	Force       bool
+	CommonFlags  *CommonFlags
+	Force        bool
+	DuoMFAOption string
 }
 
 // ApplyFlagOverrides overrides IDPAccount with command line settings


### PR DESCRIPTION
This change adds a configurable option so that users can set a flag to configure their prefered duo option (Push or Passcode). This is useful for users, who setup aliases, and want a swift and easy approach to login into the accounts.
