### PR TITLE
Change output format of AWS role selection

### DIFF
--- a/input.go
+++ b/input.go
@@ -87,7 +87,7 @@ func PromptForAWSRoleSelection(accounts []*AWSAccount) (*AWSRole, error) {
 
 	for _, account := range accounts {
 		for _, role := range account.Roles {
-			name := fmt.Sprintf("%s / %s", role.Name, account.Name)
+			name := fmt.Sprintf("%s / %s", account.Name, role.Name)
 			roles[name] = role
 			roleOptions = append(roleOptions, name)
 		}


### PR DESCRIPTION
This changes the format from `role / account` to 'account / role', which
causes the subsequent sort to sort by account name and number.

Fixes #222 

This now gives a format as such:

```
  Account: xxxxx-engineering (xxxxxxxxxx15) / administrator
  Account: xxxxx-engineering (xxxxxxxxxx15) / systemadministrator
  Account: xxx-enablers (xxxxxxxxxxx02) / administrator
  Account: xxxxxxx-development (xxxxxxxxxx30) / administrator
  Account: xxxxxxx-development (xxxxxxxxxx30) / kubernetes
  Account: xxxxx-development (xxxxxxxxxx03) / administrator
  Account: xxxxx-development (xxxxxxxxxx03) / databaseteam
```

which I think satisfies the original intent of #222 