### PR TITLE
Allow login without configure

### DIFF
--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -105,12 +105,8 @@ func buildIdpAccount(loginFlags *flags.LoginExecFlags) (*cfg.IDPAccount, error) 
 		return nil, errors.Wrap(err, "failed to load configuration")
 	}
 
-	account, err := cfgm.LoadVerifyIDPAccount(loginFlags.CommonFlags.IdpAccount)
+	account, err := cfgm.LoadIDPAccount(loginFlags.CommonFlags.IdpAccount)
 	if err != nil {
-		if cfg.IsErrIdpAccountNotFound(err) {
-			fmt.Printf("%v\n", err)
-			os.Exit(1)
-		}
 		return nil, errors.Wrap(err, "failed to load idp account")
 	}
 

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -3,7 +3,6 @@ package cfg
 import (
 	"fmt"
 	"net/url"
-	"reflect"
 
 	"github.com/mitchellh/go-homedir"
 	"github.com/pkg/errors"
@@ -167,32 +166,14 @@ func (cm *ConfigManager) LoadIDPAccount(idpAccountName string) (*IDPAccount, err
 		return nil, errors.Wrap(err, "Unable to load configuration file")
 	}
 
-	return readAccount(idpAccountName, cfg)
-}
-
-// LoadVerifyIDPAccount load the idp account and verify it isn't empty
-func (cm *ConfigManager) LoadVerifyIDPAccount(idpAccountName string) (*IDPAccount, error) {
-
-	cfg, err := ini.LoadSources(ini.LoadOptions{Loose: true}, cm.configPath)
-	if err != nil {
-		return nil, errors.Wrap(err, "Unable to load configuration file")
-	}
-
+	// attempt to map a specific idp account by name	
+	// this will return an empty account if one is not found by the given name
 	account, err := readAccount(idpAccountName, cfg)
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to read idp account")
 	}
 
-	if reflect.DeepEqual(account, NewIDPAccount()) {
-		return nil, ErrIdpAccountNotFound
-	}
-
 	return account, nil
-}
-
-// IsErrIdpAccountNotFound check if the error is a ErrIdpAccountNotFound
-func IsErrIdpAccountNotFound(err error) bool {
-	return err == ErrIdpAccountNotFound
 }
 
 func readAccount(idpAccountName string, cfg *ini.File) (*IDPAccount, error) {

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -36,37 +36,13 @@ func TestNewConfigManagerLoad(t *testing.T) {
 		Profile:              "saml",
 	}, idpAccount)
 
-	idpAccount, err = cfgm.LoadIDPAccount("test1234")
+	idpAccount, err = cfgm.LoadIDPAccount("")
 	require.Nil(t, err)
 	require.Equal(t, &IDPAccount{
 		AmazonWebservicesURN: DefaultAmazonWebservicesURN,
 		SessionDuration:      3600,
 		Profile:              "saml",
 	}, idpAccount)
-}
-
-func TestNewConfigManagerLoadVerify(t *testing.T) {
-
-	cfgm, err := NewConfigManager("example/saml2aws.ini")
-	require.Nil(t, err)
-
-	require.NotNil(t, cfgm)
-
-	idpAccount, err := cfgm.LoadVerifyIDPAccount("test123")
-	require.Nil(t, err)
-	require.Equal(t, &IDPAccount{
-		URL:                  "https://id.whatever.com",
-		Username:             "abc@whatever.com",
-		Provider:             "keycloak",
-		MFA:                  "sms",
-		AmazonWebservicesURN: DefaultAmazonWebservicesURN,
-		SessionDuration:      3600,
-		Profile:              "saml",
-	}, idpAccount)
-
-	idpAccount, err = cfgm.LoadVerifyIDPAccount("test1234")
-	require.Equal(t, ErrIdpAccountNotFound, err)
-	require.Nil(t, idpAccount)
 }
 
 func TestNewConfigManagerSave(t *testing.T) {
@@ -82,7 +58,7 @@ func TestNewConfigManagerSave(t *testing.T) {
 		Profile:  "saml",
 	})
 	require.Nil(t, err)
-	idpAccount, err := cfgm.LoadVerifyIDPAccount("testing2")
+	idpAccount, err := cfgm.LoadIDPAccount("testing2")
 	require.Nil(t, err)
 	require.Equal(t, &IDPAccount{
 		URL:                  "https://id.whatever.com",


### PR DESCRIPTION
This is a proposed fix for #109.

cfg.Validate() is used when necessary to check that the required fields
for a given account are present. LoadVerifyIDPAccount() is therefor
redundant.

- Use LoadIDPAccount() in the login command, to allow it to succeed even
if there are no configured IDP accounts.
- Completely remove LoadVerifyIDPAccount()
- Update tests as needed

Fixes #109