### PR TITLE
add quotes remove extra equals from powershell env script

### DIFF
--- a/cmd/saml2aws/commands/script.go
+++ b/cmd/saml2aws/commands/script.go
@@ -26,11 +26,11 @@ set -gx SAML2AWS_PROFILE {{ .ProfileName }}
 "
 `
 
-const powershellTmpl = `$env:AWS_ACCESS_KEY_ID={{ .AWSAccessKey }}
-$env:AWS_SECRET_ACCESS_KEY=={{ .AWSSecretKey }}
-$env:AWS_SESSION_TOKEN={{ .AWSSessionToken }}
-$env:AWS_SECURITY_TOKEN={{ .AWSSecurityToken }}
-$env:SAML2AWS_PROFILE={{ .ProfileName }}"
+const powershellTmpl = `$env:AWS_ACCESS_KEY_ID='{{ .AWSAccessKey }}'
+$env:AWS_SECRET_ACCESS_KEY='{{ .AWSSecretKey }}'
+$env:AWS_SESSION_TOKEN='{{ .AWSSessionToken }}'
+$env:AWS_SECURITY_TOKEN='{{ .AWSSecurityToken }}'
+$env:SAML2AWS_PROFILE='{{ .ProfileName }}'
 `
 
 // Script will emit a bash script that will export environment variables


### PR DESCRIPTION
These changes are to address this issue: https://github.com/Versent/saml2aws/issues/267
* removed extra quote in setting secret key
* added single quotes around the values to treat as literal strings (shouldn't execute a profile name of `$(Remove-Item "C:\Windows" -Force)`)