### PR TITLE
Add check for SAML response after first RSA code submission

### DIFF
--- a/pkg/provider/adfs2/rsa.go
+++ b/pkg/provider/adfs2/rsa.go
@@ -48,16 +48,17 @@ func (ac *Client) authenticateRsa(loginDetails *creds.LoginDetails) (string, err
 		return "", errors.Wrap(err, "error extracting rsa form data")
 	}
 
-	nextCode := prompter.Password("Enter nextCode")
+	if rsaForm.Get("SAMLResponse") == "" {
+		nextCode := prompter.Password("Enter nextCode")
 
-	rsaForm.Set("NextCode", nextCode)
-	rsaForm.Del("submit")
+		rsaForm.Set("NextCode", nextCode)
+		rsaForm.Del("submit")
 
-	doc, err = ac.postRSAForm(rsaActionURL, rsaForm)
-	if err != nil {
-		return "", errors.Wrap(err, "error posting rsa form")
+		doc, err = ac.postRSAForm(rsaActionURL, rsaForm)
+		if err != nil {
+			return "", errors.Wrap(err, "error posting rsa form")
+		}
 	}
-
 	return extractSamlAssertion(doc)
 }
 


### PR DESCRIPTION
Adding a check for a SAML response after the first RSA code is submitted enables hard and virtual tokens which do not normally require nextCode. This should fix https://github.com/Versent/saml2aws/issues/248. The current tests do not include a page for nextCode so I cannot properly test that it does not break prior behavior.