### PR TITLE
Trim whitespace on extracted role ARNs

### DIFF
--- a/aws_role.go
+++ b/aws_role.go
@@ -39,10 +39,10 @@ func parseRole(role string) (*AWSRole, error) {
 
 	for _, token := range tokens {
 		if strings.Contains(token, ":saml-provider") {
-			awsRole.PrincipalARN = token
+			awsRole.PrincipalARN = strings.TrimSpace(token)
 		}
 		if strings.Contains(token, ":role") {
-			awsRole.RoleARN = token
+			awsRole.RoleARN = strings.TrimSpace(token)
 		}
 	}
 


### PR DESCRIPTION
While the [AWS documentation](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html) describes the Role attribute as a comma-delimited list, it does not explicitly forbid whitespace in delimiter. This is probably a configuration error on the ADFS side, however, the AWS console accepts assertions containing whitespace. That being the case, it does no harm to clean the ARN after scraping it.