### PR TITLE
Jumpcloud: check if mfa_token was passed via cli before prompting

### DIFF
--- a/pkg/provider/jumpcloud/jumpcloud.go
+++ b/pkg/provider/jumpcloud/jumpcloud.go
@@ -115,7 +115,11 @@ func (jc *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 	// Get the OTP and resubmit.
 	if res.StatusCode == 401 {
 		// Get the user's MFA token and re-build the body
-		a.OTP = prompter.StringRequired("MFA Token")
+		a.OTP = loginDetails.MFAToken
+		if a.OTP == "" {
+			a.OTP = prompter.StringRequired("MFA Token")
+		}
+
 		authBody, err = json.Marshal(a)
 		if err != nil {
 			return samlAssertion, errors.Wrap(err, "error building authentication req body after getting MFA Token")


### PR DESCRIPTION
The PR fixes the current behavior where the mfa prompt doesn't consider if a token is provided via the cli flag `--mfa-token` or `SAML2AWS_MFA_TOKEN` environment variable.

*Current behavior*
```shell
saml2aws login --mfa-token=$token # MFA Token prompt
```

*Expected behaviour*
```shell
saml2aws login --mfa-token=$token # no MFA Token prompt
```