### PR TITLE
Do not ask for MFA Token if it was already provided

### DIFF
--- a/pkg/provider/jumpcloud/jumpcloud.go
+++ b/pkg/provider/jumpcloud/jumpcloud.go
@@ -115,7 +115,12 @@ func (jc *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 	// Get the OTP and resubmit.
 	if res.StatusCode == 401 {
 		// Get the user's MFA token and re-build the body
-		a.OTP = prompter.StringRequired("MFA Token")
+		if loginDetails.MFAToken == "" {
+			a.OTP = prompter.StringRequired("MFA Token")
+		} else {
+			a.OTP = loginDetails.MFAToken
+		}
+
 		authBody, err = json.Marshal(a)
 		if err != nil {
 			return samlAssertion, errors.Wrap(err, "error building authentication req body after getting MFA Token")


### PR DESCRIPTION
# Explanation

Tho user provides the `MFA Token` in the parameters using `--mfa-token`, the app still asks for it

```
[18:33] nhat.tran@hf:~ $ SAML2AWS_USERNAME=******** SAML2AWS_PASSWORD=******** saml2aws login -a live-basic --skip-prompt --mfa-token=123456
Using IDP Account live-basic to access JumpCloud https://sso.jumpcloud.com/saml2/aws-eks-live-basic
Authenticating as ******** ...
? MFA Token 123456
Response did not contain a valid SAML assertion
Please check your username and password is correct
```

# The Fix

If user already provided the token, the app doesn't need to ask for it again