### PR TITLE
login: check for empty AWS accounts in response

### DIFF
--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -204,6 +204,9 @@ func resolveRole(awsRoles []*saml2aws.AWSRole, samlAssertion string, account *cf
 	if err != nil {
 		return nil, errors.Wrap(err, "error parsing aws role accounts")
 	}
+	if len(awsAccounts) == 0 {
+		return nil, errors.New("no accounts available")
+	}
 
 	saml2aws.AssignPrincipals(awsRoles, awsAccounts)
 


### PR DESCRIPTION
An invalid SAML assertion sent to the AWS SAML signin page or any other
non-transport error (eg. 5xx status codes) would result in the prompter
in an infinite loop as it would be passed an empty list.

This just checks that we got at least 1 account back from AWS before
prompting the user.