### PR TITLE
Fix to Support ADFS5 Form Format

### DIFF
--- a/pkg/provider/adfs/adfs.go
+++ b/pkg/provider/adfs/adfs.go
@@ -185,13 +185,23 @@ func updateFormData(authForm url.Values, s *goquery.Selection, user *creds.Login
 	if !ok {
 		return
 	}
+
+	typeValue, typeFound := s.Attr("type")
+	hiddenAttr := typeFound && typeValue == "hidden"
+
 	lname := strings.ToLower(name)
 	if strings.Contains(lname, "user") {
-		authForm.Add(name, user.Username)
+		if !hiddenAttr {
+			authForm.Add(name, user.Username)
+		}
 	} else if strings.Contains(lname, "email") {
-		authForm.Add(name, user.Username)
+		if !hiddenAttr {
+			authForm.Add(name, user.Username)
+		}
 	} else if strings.Contains(lname, "pass") {
-		authForm.Add(name, user.Password)
+		if !hiddenAttr {
+			authForm.Add(name, user.Password)
+		}
 	} else {
 		// pass through any hidden fields
 		val, ok := s.Attr("value")


### PR DESCRIPTION
Fixes #283

ADFS 5.0 on Windows Server 2019 introduces a hidden field with the name
of "UserName" and the id of "userNameInputOptionsHolder". saml2aws will
include this in the fields which it populates when submitting a request
to ADFS.

ADFS encounters an error when both "UserName" fields are populated, so
this change ensures that only "user" and "password" fields which are
visible to the user will be populated by saml2aws and submitted to ADFS.