### PR TITLE
Add disable-keychain option and implementation

### DIFF
--- a/cmd/saml2aws/commands/configure.go
+++ b/cmd/saml2aws/commands/configure.go
@@ -64,7 +64,9 @@ func Configure(configFlags *flags.CommonFlags) error {
 }
 
 func storeCredentials(configFlags *flags.CommonFlags, account *cfg.IDPAccount) error {
-
+	if configFlags.NoKeychain {
+		return nil
+	}
 	if configFlags.Password != "" {
 		if err := credentials.SaveCredentials(account.URL, account.Username, configFlags.Password); err != nil {
 			return errors.Wrap(err, "error storing password in keychain")

--- a/cmd/saml2aws/commands/configure.go
+++ b/cmd/saml2aws/commands/configure.go
@@ -64,7 +64,7 @@ func Configure(configFlags *flags.CommonFlags) error {
 }
 
 func storeCredentials(configFlags *flags.CommonFlags, account *cfg.IDPAccount) error {
-	if configFlags.NoKeychain {
+	if configFlags.DisableKeychain {
 		return nil
 	}
 	if configFlags.Password != "" {

--- a/cmd/saml2aws/commands/list_roles.go
+++ b/cmd/saml2aws/commands/list_roles.go
@@ -52,9 +52,11 @@ func ListRoles(loginFlags *flags.LoginExecFlags) error {
 		os.Exit(1)
 	}
 
-	err = credentials.SaveCredentials(loginDetails.URL, loginDetails.Username, loginDetails.Password)
-	if err != nil {
-		return errors.Wrap(err, "error storing password in keychain")
+	if !loginFlags.CommonFlags.NoKeychain {
+		err = credentials.SaveCredentials(loginDetails.URL, loginDetails.Username, loginDetails.Password)
+		if err != nil {
+			return errors.Wrap(err, "error storing password in keychain")
+		}
 	}
 
 	data, err := base64.StdEncoding.DecodeString(samlAssertion)

--- a/cmd/saml2aws/commands/list_roles.go
+++ b/cmd/saml2aws/commands/list_roles.go
@@ -52,7 +52,7 @@ func ListRoles(loginFlags *flags.LoginExecFlags) error {
 		os.Exit(1)
 	}
 
-	if !loginFlags.CommonFlags.NoKeychain {
+	if !loginFlags.CommonFlags.DisableKeychain {
 		err = credentials.SaveCredentials(loginDetails.URL, loginDetails.Username, loginDetails.Password)
 		if err != nil {
 			return errors.Wrap(err, "error storing password in keychain")

--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -79,7 +79,7 @@ func Login(loginFlags *flags.LoginExecFlags) error {
 		os.Exit(1)
 	}
 
-	if !loginFlags.CommonFlags.NoKeychain {
+	if !loginFlags.CommonFlags.DisableKeychain {
 		err = credentials.SaveCredentials(loginDetails.URL, loginDetails.Username, loginDetails.Password)
 		if err != nil {
 			return errors.Wrap(err, "error storing password in keychain")
@@ -132,7 +132,7 @@ func resolveLoginDetails(account *cfg.IDPAccount, loginFlags *flags.LoginExecFla
 	fmt.Printf("Using IDP Account %s to access %s %s\n", loginFlags.CommonFlags.IdpAccount, account.Provider, account.URL)
 
 	var err error
-	if !loginFlags.CommonFlags.NoKeychain {
+	if !loginFlags.CommonFlags.DisableKeychain {
 		err = credentials.LookupCredentials(loginDetails, account.Provider)
 		if err != nil {
 			if !credentials.IsErrCredentialsNotFound(err) {

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -64,7 +64,7 @@ func main() {
 	app.Flag("aws-urn", "The URN used by SAML when you login. (env: SAML2AWS_AWS_URN)").Envar("SAML2AWS_AWS_URN").StringVar(&commonFlags.AmazonWebservicesURN)
 	app.Flag("skip-prompt", "Skip prompting for parameters during login.").BoolVar(&commonFlags.SkipPrompt)
 	app.Flag("session-duration", "The duration of your AWS Session. (env: SAML2AWS_SESSION_DURATION)").Envar("SAML2AWS_SESSION_DURATION").IntVar(&commonFlags.SessionDuration)
-	app.Flag("no-keychain", "Do not use keychain at all.").BoolVar(&commonFlags.NoKeychain)
+	app.Flag("disable-keychain", "Do not use keychain at all.").BoolVar(&commonFlags.DisableKeychain)
 
 	// `configure` command and settings
 	cmdConfigure := app.Command("configure", "Configure a new IDP account.")

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -64,7 +64,7 @@ func main() {
 	app.Flag("aws-urn", "The URN used by SAML when you login. (env: SAML2AWS_AWS_URN)").Envar("SAML2AWS_AWS_URN").StringVar(&commonFlags.AmazonWebservicesURN)
 	app.Flag("skip-prompt", "Skip prompting for parameters during login.").BoolVar(&commonFlags.SkipPrompt)
 	app.Flag("session-duration", "The duration of your AWS Session. (env: SAML2AWS_SESSION_DURATION)").Envar("SAML2AWS_SESSION_DURATION").IntVar(&commonFlags.SessionDuration)
-	app.Flag("disable-keychain", "Do not use keychain at all.").BoolVar(&commonFlags.DisableKeychain)
+	app.Flag("disable-keychain", "Do not use keychain at all.").Envar("SAML2AWS_DISABLE_KEYCHAIN").BoolVar(&commonFlags.DisableKeychain)
 
 	// `configure` command and settings
 	cmdConfigure := app.Command("configure", "Configure a new IDP account.")

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -64,6 +64,7 @@ func main() {
 	app.Flag("aws-urn", "The URN used by SAML when you login. (env: SAML2AWS_AWS_URN)").Envar("SAML2AWS_AWS_URN").StringVar(&commonFlags.AmazonWebservicesURN)
 	app.Flag("skip-prompt", "Skip prompting for parameters during login.").BoolVar(&commonFlags.SkipPrompt)
 	app.Flag("session-duration", "The duration of your AWS Session. (env: SAML2AWS_SESSION_DURATION)").Envar("SAML2AWS_SESSION_DURATION").IntVar(&commonFlags.SessionDuration)
+	app.Flag("no-keychain", "Do not use keychain at all.").BoolVar(&commonFlags.NoKeychain)
 
 	// `configure` command and settings
 	cmdConfigure := app.Command("configure", "Configure a new IDP account.")

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -25,6 +25,7 @@ type CommonFlags struct {
 	Profile              string
 	Subdomain            string
 	ResourceID           string
+	NoKeychain           bool
 }
 
 // LoginExecFlags flags for the Login / Exec commands

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -25,7 +25,7 @@ type CommonFlags struct {
 	Profile              string
 	Subdomain            string
 	ResourceID           string
-	NoKeychain           bool
+	DisableKeychain      bool
 }
 
 // LoginExecFlags flags for the Login / Exec commands


### PR DESCRIPTION
Someone who uses [pass](https://www.passwordstore.org/) or other password managers to manage their credentials, storing credential into keychain can be an inconvenient option. This patch provides `--disable-keychain` option which disables behavior that storing credential into their local keychain.