### PR TITLE
External provider

### DIFF
--- a/pkg/provider/shell/shell.go
+++ b/pkg/provider/shell/shell.go
@@ -1,0 +1,30 @@
+package shell
+
+import (
+	"os/exec"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/versent/saml2aws/pkg/cfg"
+	"github.com/versent/saml2aws/pkg/creds"
+)
+
+var logger = logrus.WithField("provider", "shell")
+
+// Client is a wrapper representing an External SAML client
+type Client struct {
+}
+
+// New creates a new external client
+func New(idpAccount *cfg.IDPAccount) (*Client, error) {
+	c := &Client{}
+	return c, nil
+}
+
+// Authenticate executes the URL as a local command, excepting a base64-encoded SAML Assertion
+func (oc *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error) {
+	logger.Infof("Executing %s", loginDetails.URL)
+	cmd := exec.Command("sh", "-c", loginDetails.URL)
+	samlResponse, err := cmd.Output()
+	return string(samlResponse), err
+}

--- a/saml2aws.go
+++ b/saml2aws.go
@@ -9,6 +9,7 @@ import (
 	"github.com/versent/saml2aws/pkg/provider/aad"
 	"github.com/versent/saml2aws/pkg/provider/adfs"
 	"github.com/versent/saml2aws/pkg/provider/adfs2"
+	"github.com/versent/saml2aws/pkg/provider/akamai"
 	"github.com/versent/saml2aws/pkg/provider/f5apm"
 	"github.com/versent/saml2aws/pkg/provider/googleapps"
 	"github.com/versent/saml2aws/pkg/provider/jumpcloud"
@@ -18,8 +19,8 @@ import (
 	"github.com/versent/saml2aws/pkg/provider/pingfed"
 	"github.com/versent/saml2aws/pkg/provider/pingone"
 	"github.com/versent/saml2aws/pkg/provider/psu"
+	"github.com/versent/saml2aws/pkg/provider/shell"
 	"github.com/versent/saml2aws/pkg/provider/shibboleth"
-	"github.com/versent/saml2aws/pkg/provider/akamai"
 	"github.com/versent/saml2aws/pkg/provider/shibbolethecp"
 )
 
@@ -163,7 +164,8 @@ func NewSAMLClient(idpAccount *cfg.IDPAccount) (SAMLClient, error) {
 			return nil, fmt.Errorf("Invalid MFA type: %v for %v provider", idpAccount.MFA, idpAccount.Provider)
 		}
 		return akamai.New(idpAccount)
-
+	case "Shell":
+		return shell.New(idpAccount)
 	default:
 		return nil, fmt.Errorf("Invalid provider: %v", idpAccount.Provider)
 	}


### PR DESCRIPTION
Add new "external" provider that shells out to a separate script to retrieve the SAML response.
Uses the URL field as the command to pass to /bin/sh to execute.

Tested locally with an external script that hijacks the existing browser session to retrieve the SAML response, however could be used with anything really.