### PR TITLE
Fixes Okta MFA so that it works with TOTP

### DIFF
--- a/pkg/creds/creds.go
+++ b/pkg/creds/creds.go
@@ -11,6 +11,7 @@ type LoginDetails struct {
 	MFAToken     string
 	DuoMFAOption string
 	URL          string
+	StateToken   string // used by Okta
 }
 
 // Validate validate the login details

--- a/pkg/provider/okta/README.md
+++ b/pkg/provider/okta/README.md
@@ -12,8 +12,4 @@ The path segments `/home/amazon_aws` in the above URL may vary.
 
 ## Features
 
-* Supports MFA (Okta Push, Okta TOTP, Duo, and Google Authenticator), when configured at *organization level*.
-
-## Limitations
-
-* Does **not** support application-level MFA, per [issue #118](https://github.com/Versent/saml2aws/issues/118#issuecomment-355688008)
+* Supports MFA (Okta Push, Okta TOTP, Duo, and Google Authenticator), when configured at *organization* or *application* level.

--- a/pkg/provider/okta/okta_test.go
+++ b/pkg/provider/okta/okta_test.go
@@ -1,0 +1,48 @@
+package okta
+
+import (
+	"testing"
+	"errors"
+	"github.com/stretchr/testify/assert"
+)
+
+type stateTokenTests struct {
+	title string
+	body string
+	stateToken string
+	err error
+}
+
+func TestGetStateTokenFromOktaPageBody(t *testing.T) {
+	tests := []stateTokenTests{
+		{
+			title: "State token in body gets returned",
+			body: "someJavascriptCode();\nvar stateToken = '123456789';\nsomeOtherJavaScriptCode();",
+			stateToken: "123456789",
+			err: nil,
+		},
+		{
+			title: "State token not in body casues error",
+			body: "someJavascriptCode();\nsomeOtherJavaScriptCode();",
+			stateToken: "",
+			err: errors.New("cannot find state token"),
+		},
+		{
+			title: "State token with hypen handled correctly",
+			body: "someJavascriptCode();\nvar stateToken = '12345\x2D6789';\nsomeOtherJavaScriptCode();",
+			stateToken: "12345-6789",
+			err: nil,
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			stateToken, err := getStateTokenFromOktaPageBody(test.body)
+			assert.Equal(t, test.stateToken, stateToken)
+			if test.err != nil {
+				assert.NotNil(t, err)
+				assert.Equal(t, test.err.Error(), err.Error())
+			}
+			
+		})
+	}
+}


### PR DESCRIPTION
I wasn't able to get `saml2aws` to work with Okta using MFA for our organization. We have the "Okta Verify" MFA (in reality just a TOTP scheme) configured for our AWS account and I was getting the "response does not contain a valid SAML assertion" error from https://github.com/Versent/saml2aws/issues/118.

According to [Okta support](https://support.okta.com/help/s/article/Integrating-the-Amazon-Web-Services-Command-Line-Interface-Using-Okta) the "preferred solution" is gimme-aws-creds. I looked at [their code](https://github.com/Nike-Inc/gimme-aws-creds/blob/master/gimme_aws_creds/okta.py#L543-L548) and see they grabbed the state token from the page and resubmit to the `authn` endpoint.

Using that approach, I was able to get `saml2aws` to ask for my MFA code and return a valid AWS session.

Happy to update or add any additional comments/documentation. Thanks!