### PR TITLE
Issue#378: Pass through session-duration flag for exec

### DIFF
--- a/cmd/saml2aws/commands/exec.go
+++ b/cmd/saml2aws/commands/exec.go
@@ -78,17 +78,17 @@ func Exec(execFlags *flags.LoginExecFlags, cmdline []string) error {
 // assumeRoleWithProfile uses an AWS profile (via ~/.aws/config) and performs (multiple levels of) role assumption
 // This is extremely useful in the case of a central "authentication account" which then requires secondary, and
 // often tertiary, role assumptions to acquire credentials for the target role.
-func assumeRoleWithProfile(targetProfile string, sessionDuration int) (*awsconfig.AWSCredentials, error)  {
+func assumeRoleWithProfile(targetProfile string, sessionDuration int) (*awsconfig.AWSCredentials, error) {
 	// AWS session config with verbose errors on chained credential errors
 	config := *aws.NewConfig().WithCredentialsChainVerboseErrors(true)
-	duration, _  := time.ParseDuration(strconv.Itoa(sessionDuration) + "s")
+	duration, _ := time.ParseDuration(strconv.Itoa(sessionDuration) + "s")
 
 	// a session forcing usage of the aws config file, sets the target profile which will be found in the config
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		Config:            	config,
-		Profile:           	targetProfile,
-		SharedConfigState: 	session.SharedConfigEnable,
-		AssumeRoleDuration:   duration,
+		Config:             config,
+		Profile:            targetProfile,
+		SharedConfigState:  session.SharedConfigEnable,
+		AssumeRoleDuration: duration,
 	}))
 
 	// use an STS client to perform the multiple role assumptions
@@ -104,9 +104,9 @@ func assumeRoleWithProfile(targetProfile string, sessionDuration int) (*awsconfi
 		return nil, err
 	}
 	return &awsconfig.AWSCredentials{
-		AWSAccessKey:     creds.AccessKeyID,
-		AWSSecretKey:     creds.SecretAccessKey,
-		AWSSessionToken:  creds.SessionToken,
+		AWSAccessKey:    creds.AccessKeyID,
+		AWSSecretKey:    creds.SecretAccessKey,
+		AWSSessionToken: creds.SessionToken,
 	}, nil
 }
 

--- a/cmd/saml2aws/commands/exec.go
+++ b/cmd/saml2aws/commands/exec.go
@@ -81,7 +81,6 @@ func Exec(execFlags *flags.LoginExecFlags, cmdline []string) error {
 func assumeRoleWithProfile(targetProfile string, sessionDuration int) (*awsconfig.AWSCredentials, error)  {
 	// AWS session config with verbose errors on chained credential errors
 	config := *aws.NewConfig().WithCredentialsChainVerboseErrors(true)
-	print(strconv.Itoa(sessionDuration))
 	duration, _  := time.ParseDuration(strconv.Itoa(sessionDuration) + "s")
 
 	// a session forcing usage of the aws config file, sets the target profile which will be found in the config

--- a/cmd/saml2aws/commands/exec.go
+++ b/cmd/saml2aws/commands/exec.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	"fmt"
+	"strconv"
 	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
@@ -64,7 +65,7 @@ func Exec(execFlags *flags.LoginExecFlags, cmdline []string) error {
 
 	if execFlags.ExecProfile != "" {
 		// Assume the desired role before generating env vars
-		awsCreds, err = assumeRoleWithProfile(execFlags.ExecProfile)
+		awsCreds, err = assumeRoleWithProfile(execFlags.ExecProfile, execFlags.CommonFlags.SessionDuration)
 		if err != nil {
 			return errors.Wrap(err,
 				fmt.Sprintf("error acquiring credentials for profile: %s", execFlags.ExecProfile))
@@ -77,15 +78,18 @@ func Exec(execFlags *flags.LoginExecFlags, cmdline []string) error {
 // assumeRoleWithProfile uses an AWS profile (via ~/.aws/config) and performs (multiple levels of) role assumption
 // This is extremely useful in the case of a central "authentication account" which then requires secondary, and
 // often tertiary, role assumptions to acquire credentials for the target role.
-func assumeRoleWithProfile(targetProfile string) (*awsconfig.AWSCredentials, error)  {
+func assumeRoleWithProfile(targetProfile string, sessionDuration int) (*awsconfig.AWSCredentials, error)  {
 	// AWS session config with verbose errors on chained credential errors
 	config := *aws.NewConfig().WithCredentialsChainVerboseErrors(true)
+	print(strconv.Itoa(sessionDuration))
+	duration, _  := time.ParseDuration(strconv.Itoa(sessionDuration) + "s")
 
 	// a session forcing usage of the aws config file, sets the target profile which will be found in the config
 	sess := session.Must(session.NewSessionWithOptions(session.Options{
-		Config:            config,
-		Profile:           targetProfile,
-		SharedConfigState: session.SharedConfigEnable,
+		Config:            	config,
+		Profile:           	targetProfile,
+		SharedConfigState: 	session.SharedConfigEnable,
+		AssumeRoleDuration:   duration,
 	}))
 
 	// use an STS client to perform the multiple role assumptions


### PR DESCRIPTION
See Issue #378 

session-duration flag is not being passed through for exec action therefore sessions were receiving the default of 15 minutes (900 seconds). 

This will allow for valid values to be passed through.

If using credentials: (minimum- 900, maximum- 43200)
If using temporary credentials via role assumption: (minimum- 900, maximum- 3600) 

These are AWS limits and are not configurable from saml2aws.