### PR TITLE
OneLogin API credential is received as an argument during login

### DIFF
--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -153,6 +153,16 @@ func resolveLoginDetails(account *cfg.IDPAccount, loginFlags *flags.LoginExecFla
 		loginDetails.Password = loginFlags.CommonFlags.Password
 	}
 
+	// if you supply a cleint_id in a flag it takes precedence
+	if loginFlags.CommonFlags.ClientID != "" {
+		loginDetails.ClientID = loginFlags.CommonFlags.ClientID
+	}
+
+	// if you supply a client_secret in a flag it takes precedence
+	if loginFlags.CommonFlags.ClientSecret != "" {
+		loginDetails.ClientSecret = loginFlags.CommonFlags.ClientSecret
+	}
+
 	// fmt.Printf("loginDetails %+v\n", loginDetails)
 
 	// if skip prompt was passed just pass back the flag values

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -83,6 +83,8 @@ func main() {
 	loginFlags.CommonFlags = commonFlags
 	cmdLogin.Flag("profile", "The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)").Short('p').Envar("SAML2AWS_PROFILE").StringVar(&commonFlags.Profile)
 	cmdLogin.Flag("duo-mfa-option", "The MFA option you want to use to authenticate with").Envar("SAML2AWS_DUO_MFA_OPTION").EnumVar(&loginFlags.DuoMFAOption, "Passcode", "Duo Push")
+	cmdLogin.Flag("client-id", "OneLogin client id, used to generate API access token. (env: ONELOGIN_CLIENT_ID)").Envar("ONELOGIN_CLIENT_ID").StringVar(&commonFlags.ClientID)
+	cmdLogin.Flag("client-secret", "OneLogin client secret, used to generate API access token. (env: ONELOGIN_CLIENT_SECRET)").Envar("ONELOGIN_CLIENT_SECRET").StringVar(&commonFlags.ClientSecret)
 	cmdLogin.Flag("force", "Refresh credentials even if not expired.").BoolVar(&loginFlags.Force)
 
 	// `exec` command and settings

--- a/input.go
+++ b/input.go
@@ -68,14 +68,18 @@ func PromptForLoginDetails(loginDetails *creds.LoginDetails, provider string) er
 	}
 	fmt.Println("")
 	if provider == "OneLogin" {
-		if enteredClientID := prompter.Password("Client ID"); enteredClientID != "" {
-			loginDetails.ClientID = enteredClientID
+		if loginDetails.ClientID == "" {
+			if enteredClientID := prompter.Password("Client ID"); enteredClientID != "" {
+				loginDetails.ClientID = enteredClientID
+			}
+			fmt.Println("")
 		}
-		fmt.Println("")
-		if enteredCientSecret := prompter.Password("Client Secret"); enteredCientSecret != "" {
-			loginDetails.ClientSecret = enteredCientSecret
+		if loginDetails.ClientSecret == "" {
+			if enteredCientSecret := prompter.Password("Client Secret"); enteredCientSecret != "" {
+				loginDetails.ClientSecret = enteredCientSecret
+			}
+			fmt.Println("")
 		}
-		fmt.Println("")
 	}
 
 	return nil


### PR DESCRIPTION
Every time I login using OneLogin as the Provider, I was asked the OneLogin Client ID and Client Secret, which was cumbersome.
So we changed it to allow passing API credentials from arguments or environment variables as well as the configure subcommand.