### PR TITLE
Target test depends on prepare

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ dist:
 release:
 	@$(BIN_DIR)/github-release "v$(VERSION)" dist/* --commit "$(git rev-parse HEAD)" --github-repository versent/$(NAME)
 
-test:
+test: prepare
 	@$(BIN_DIR)/gocov test $(SOURCE_FILES) | $(BIN_DIR)/gocov report
 
 clean:


### PR DESCRIPTION
Test can not be run if prepare has not downloaded `gocov` yet so currently when following the README, running the tests will fail.