### PR TITLE
feat(console) Log into the AWS console from saml2aws

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,37 +115,25 @@ usage: saml2aws [<flags>] <command> [<args> ...]
 A command line tool to help with SAML access to the AWS token service.
 
 Flags:
-      --help                   Show context-sensitive help (also try --help-long
-                               and --help-man).
+      --help                   Show context-sensitive help (also try --help-long and --help-man).
       --version                Show application version.
       --verbose                Enable verbose logging
-  -i, --provider=PROVIDER      This flag is obsolete. See:
-                               https://github.com/Versent/saml2aws#configuring-idp-accounts
-  -a, --idp-account="default"  The name of the configured IDP account. (env:
-                               SAML2AWS_IDP_ACCOUNT)
+  -i, --provider=PROVIDER      This flag is obsolete. See: https://github.com/Versent/saml2aws#configuring-idp-accounts
+  -a, --idp-account="default"  The name of the configured IDP account. (env: SAML2AWS_IDP_ACCOUNT)
       --idp-provider=IDP-PROVIDER
-                               The configured IDP provider. (env:
-                               SAML2AWS_IDP_PROVIDER)
+                               The configured IDP provider. (env: SAML2AWS_IDP_PROVIDER)
       --mfa=MFA                The name of the mfa. (env: SAML2AWS_MFA)
-  -s, --skip-verify            Skip verification of server certificate.
-      --url=URL                The URL of the SAML IDP server used to login.
-                               (env: SAML2AWS_URL)
-      --username=USERNAME      The username used to login. (env:
-                               SAML2AWS_USERNAME)
-      --password=PASSWORD      The password used to login. (env:
-                               SAML2AWS_PASSWORD)
-      --mfa-token=MFA-TOKEN    The current MFA token (supported in Keycloak,
-                               ADFS, GoogleApps). (env: SAML2AWS_MFA_TOKEN)
-      --role=ROLE              The ARN of the role to assume. (env:
-                               SAML2AWS_ROLE)
-      --aws-urn=AWS-URN        The URN used by SAML when you login. (env:
-                               SAML2AWS_AWS_URN)
-      --duo-mfa-option         The MFA option you want to use to authenticate (env: SAML_DUO_MFA_OPTION)
+  -s, --skip-verify            Skip verification of server certificate. (env: SAML2AWS_SKIP_VERIFY)
+      --url=URL                The URL of the SAML IDP server used to login. (env: SAML2AWS_URL)
+      --username=USERNAME      The username used to login. (env: SAML2AWS_USERNAME)
+      --password=PASSWORD      The password used to login. (env: SAML2AWS_PASSWORD)
+      --mfa-token=MFA-TOKEN    The current MFA token (supported in Keycloak, ADFS, GoogleApps). (env: SAML2AWS_MFA_TOKEN)
+      --role=ROLE              The ARN of the role to assume. (env: SAML2AWS_ROLE)
+      --aws-urn=AWS-URN        The URN used by SAML when you login. (env: SAML2AWS_AWS_URN)
       --skip-prompt            Skip prompting for parameters during login.
-      --exec-profile           Execute the given command utilizing a specific profile from your ~/.aws/config file
       --session-duration=SESSION-DURATION
-                               The duration of your AWS Session. (env:
-                               SAML2AWS_SESSION_DURATION)
+                               The duration of your AWS Session. (env: SAML2AWS_SESSION_DURATION)
+      --disable-keychain       Do not use keychain at all.
 
 Commands:
   help [<command>...]
@@ -160,11 +148,15 @@ Commands:
   exec [<flags>] [<command>...]
     Exec the supplied command with env vars from STS token.
 
+  console [<flags>]
+    Console will open the aws console after logging in.
+
   list-roles
     List available role ARNs.
 
   script [<flags>]
     Emit a script that will export environment variables.
+
 ```
 
 

--- a/cmd/saml2aws/commands/console.go
+++ b/cmd/saml2aws/commands/console.go
@@ -1,0 +1,128 @@
+package commands
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/pkg/errors"
+	"github.com/skratchdot/open-golang/open"
+	"github.com/versent/saml2aws/pkg/awsconfig"
+	"github.com/versent/saml2aws/pkg/flags"
+)
+
+// Exec execute the supplied command after seeding the environment
+func Console(consoleFlags *flags.LoginExecFlags) error {
+
+	account, err := buildIdpAccount(consoleFlags)
+	if err != nil {
+		return errors.Wrap(err, "error building login details")
+	}
+
+	sharedCreds := awsconfig.NewSharedCredentials(account.Profile)
+
+	// this checks if the credentials file has been created yet
+	// can only really be triggered if saml2aws exec is run on a new
+	// system prior to creating $HOME/.aws
+	exist, err := sharedCreds.CredsExists()
+	if err != nil {
+		return errors.Wrap(err, "error loading credentials")
+	}
+	if !exist {
+		fmt.Println("unable to load credentials, login required to create them")
+		return nil
+	}
+
+	awsCreds, err := sharedCreds.Load()
+	if err != nil {
+		return errors.Wrap(err, "error loading credentials")
+	}
+
+	if awsCreds.Expires.Sub(time.Now()) < 0 {
+		return errors.New("error aws credentials have expired")
+	}
+
+	ok, err := checkToken(account.Profile)
+	if err != nil {
+		return errors.Wrap(err, "error validating token")
+	}
+
+	if !ok {
+		err = Login(consoleFlags)
+	}
+	if err != nil {
+		return errors.Wrap(err, "error logging in")
+	}
+
+	if consoleFlags.ExecProfile != "" {
+		// Assume the desired role before generating env vars
+		awsCreds, err = assumeRoleWithProfile(consoleFlags.ExecProfile, consoleFlags.CommonFlags.SessionDuration)
+		if err != nil {
+			return errors.Wrap(err,
+				fmt.Sprintf("error acquiring credentials for profile: %s", consoleFlags.ExecProfile))
+		}
+	}
+
+	fmt.Printf("Opening console for profile %s ...\n", account.Profile)
+
+	return federatedLogin(awsCreds, consoleFlags)
+}
+
+func federatedLogin(creds *awsconfig.AWSCredentials, consoleFlags *flags.LoginExecFlags) error {
+	jsonBytes, err := json.Marshal(map[string]string{
+		"sessionId":    creds.AWSAccessKey,
+		"sessionKey":   creds.AWSSecretKey,
+		"sessionToken": creds.AWSSessionToken,
+	})
+	if err != nil {
+		return err
+	}
+
+	req, err := http.NewRequest("GET", "https://signin.aws.amazon.com/federation", nil)
+	if err != nil {
+		return err
+	}
+	q := req.URL.Query()
+	q.Add("Action", "getSigninToken")
+	q.Add("Session", string(jsonBytes))
+
+	req.URL.RawQuery = q.Encode()
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return err
+	}
+
+	defer resp.Body.Close()
+	body, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	if resp.StatusCode != http.StatusOK {
+		return fmt.Errorf("Call to getSigninToken failed with %v", resp.Status)
+	}
+
+	var respParsed map[string]string
+	if err = json.Unmarshal([]byte(body), &respParsed); err != nil {
+		return err
+	}
+
+	signinToken, ok := respParsed["SigninToken"]
+	if !ok {
+		return err
+	}
+
+	destination := "https://console.aws.amazon.com/"
+
+	loginURL := fmt.Sprintf(
+		"https://signin.aws.amazon.com/federation?Action=login&Issuer=aws-okta&Destination=%s&SigninToken=%s",
+		url.QueryEscape(destination),
+		url.QueryEscape(signinToken),
+	)
+
+	return open.Run(loginURL)
+}

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -95,6 +95,12 @@ func main() {
 	cmdExec.Flag("exec-profile", "The AWS profile to utilize for command execution. Useful to allow the aws cli to perform secondary role assumption. (env: SAML2AWS_EXEC_PROFILE)").Envar("SAML2AWS_EXEC_PROFILE").StringVar(&execFlags.ExecProfile)
 	cmdLine := buildCmdList(cmdExec.Arg("command", "The command to execute."))
 
+	// `console` command and settings
+	cmdConsole := app.Command("console", "Console will open the aws console after logging in.")
+	consoleFlags := new(flags.LoginExecFlags)
+	consoleFlags.CommonFlags = commonFlags
+	cmdConsole.Flag("profile", "The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)").Envar("SAML2AWS_PROFILE").Short('p').StringVar(&commonFlags.Profile)
+
 	// `list` command and settings
 	cmdListRoles := app.Command("list-roles", "List available role ARNs.")
 	listRolesFlags := new(flags.LoginExecFlags)
@@ -140,6 +146,8 @@ func main() {
 		err = commands.Login(loginFlags)
 	case cmdExec.FullCommand():
 		err = commands.Exec(execFlags, *cmdLine)
+	case cmdConsole.FullCommand():
+		err = commands.Console(consoleFlags)
 	case cmdListRoles.FullCommand():
 		err = commands.ListRoles(listRolesFlags)
 	case cmdConfigure.FullCommand():

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/onsi/gomega v1.7.0 // indirect
 	github.com/pkg/errors v0.8.1
 	github.com/sirupsen/logrus v1.0.5
+	github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966
 	github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 // indirect
 	github.com/stretchr/objx v0.2.0 // indirect
 	github.com/stretchr/testify v1.4.0

--- a/go.sum
+++ b/go.sum
@@ -90,6 +90,8 @@ github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZb
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/sirupsen/logrus v1.0.5 h1:8c8b5uO0zS4X6RPl/sd1ENwSkIc0/H2PaHxE3udaE8I=
 github.com/sirupsen/logrus v1.0.5/go.mod h1:pMByvHTf9Beacp5x1UXfOR9xyW/9antXMhjMPG0dEzc=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966 h1:JIAuq3EEf9cgbU6AtGPK4CTG3Zf6CKMNqf0MHTggAUA=
+github.com/skratchdot/open-golang v0.0.0-20200116055534-eef842397966/go.mod h1:sUM3LWHvSMaG192sy56D9F7CNvL7jUJVXoqM1QKLnog=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d h1:zE9ykElWQ6/NYmHa3jpm/yHnI4xSofP+UP6SpjHcSeM=
 github.com/smartystreets/assertions v0.0.0-20180927180507-b2de0cb4f26d/go.mod h1:OnSkiWE9lh6wB0YB77sQom3nweQdgAjqCqsofrRNTgc=
 github.com/smartystreets/goconvey v0.0.0-20190731233626-505e41936337 h1:WN9BUFbdyOsSH/XohnWpXOlq9NBD5sGAB2FciQMUEe8=


### PR DESCRIPTION
As per https://segment.com/blog/secure-access-to-100-aws-accounts/ I have implemented AWS console login directly from saml2aws.

This will open using your default browser.

Note: Like the exec command, if your credentials are still active this will not prompt for login.