### PR TITLE
Export AWS_CREDENTIAL_EXPIRATION with token expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,6 +168,7 @@ export AWS_ACCESS_KEY_ID="ASIAI....UOCA"
 export AWS_SECRET_ACCESS_KEY="DuH...G1d"
 export AWS_SESSION_TOKEN="AQ...1BQ=="
 export AWS_SECURITY_TOKEN="AQ...1BQ=="
+export AWS_CREDENTIAL_EXPIRATION="2016-09-04T38:27:00Z00:00"
 SAML2AWS_PROFILE=saml
 ```
 
@@ -428,6 +429,7 @@ AWS_ACCESS_KEY_ID=AAAAAAAASORTENED
 AWS_SECRET_ACCESS_KEY=secretShortened+6jJ5SMqsM5CkYi3Gw7
 AWS_SESSION_TOKEN=ShortenedTokenXXX=
 AWS_SECURITY_TOKEN=ShortenedSecurityTokenXXX=
+AWS_CREDENTIAL_EXPIRATION=2016-09-04T38:27:00Z00:00
 
 # If we desire to execute multiple commands utilizing our assumed profile, we can obtain a new shell with Env variables configured for access
 
@@ -485,6 +487,7 @@ The exec sub command will export the following environment variables.
 * EC2_SECURITY_TOKEN
 * AWS_PROFILE
 * AWS_DEFAULT_PROFILE
+* AWS_CREDENTIAL_EXPIRATION
 
 Note: That profile environment variables enable you to use `exec` with a script or command which requires an explicit profile.
 

--- a/cmd/saml2aws/commands/script.go
+++ b/cmd/saml2aws/commands/script.go
@@ -16,6 +16,7 @@ export AWS_SECRET_ACCESS_KEY="{{ .AWSSecretKey }}"
 export AWS_SESSION_TOKEN="{{ .AWSSessionToken }}"
 export AWS_SECURITY_TOKEN="{{ .AWSSecurityToken }}"
 export SAML2AWS_PROFILE="{{ .ProfileName }}"
+export AWS_CREDENTIAL_EXPIRATION="{{ .Expires.Format "2006-01-02T15:04:05Z07:00" }}"
 `
 
 const fishTmpl = `set -gx AWS_ACCESS_KEY_ID {{ .AWSAccessKey }}
@@ -23,6 +24,7 @@ set -gx AWS_SECRET_ACCESS_KEY {{ .AWSSecretKey }}
 set -gx AWS_SESSION_TOKEN {{ .AWSSessionToken }}
 set -gx AWS_SECURITY_TOKEN {{ .AWSSecurityToken }}
 set -gx SAML2AWS_PROFILE {{ .ProfileName }}
+set -gx AWS_CREDENTIAL_EXPIRATION={{ .Expires "2006-01-02T15:04:05Z07:00" }}
 "
 `
 
@@ -31,6 +33,7 @@ $env:AWS_SECRET_ACCESS_KEY='{{ .AWSSecretKey }}'
 $env:AWS_SESSION_TOKEN='{{ .AWSSessionToken }}'
 $env:AWS_SECURITY_TOKEN='{{ .AWSSecurityToken }}'
 $env:SAML2AWS_PROFILE='{{ .ProfileName }}'
+$env:AWS_CREDENTIAL_EXPIRATION='{{ .Expires "2006-01-02T15:04:05Z07:00" }}'
 `
 
 // Script will emit a bash script that will export environment variables

--- a/pkg/shell/env.go
+++ b/pkg/shell/env.go
@@ -2,6 +2,7 @@ package shell
 
 import (
 	"fmt"
+	"time"
 	"github.com/versent/saml2aws/pkg/awsconfig"
 	"github.com/versent/saml2aws/pkg/cfg"
 	"github.com/versent/saml2aws/pkg/flags"
@@ -16,6 +17,7 @@ func BuildEnvVars(awsCreds *awsconfig.AWSCredentials, account *cfg.IDPAccount, e
 		fmt.Sprintf("EC2_SECURITY_TOKEN=%s", awsCreds.AWSSecurityToken),
 		fmt.Sprintf("AWS_ACCESS_KEY_ID=%s", awsCreds.AWSAccessKey),
 		fmt.Sprintf("AWS_SECRET_ACCESS_KEY=%s", awsCreds.AWSSecretKey),
+		fmt.Sprintf("AWS_CREDENTIAL_EXPIRATION=%s", awsCreds.Expires.Format(time.RFC3339)),
 	}
 
 	if execFlags.ExecProfile == "" {

--- a/pkg/shell/env_test.go
+++ b/pkg/shell/env_test.go
@@ -3,6 +3,7 @@ package shell
 import (
 	"reflect"
 	"testing"
+	"time"
 
 	"github.com/versent/saml2aws/pkg/awsconfig"
 	"github.com/versent/saml2aws/pkg/cfg"
@@ -18,6 +19,7 @@ func TestBuildEnvVars(t *testing.T) {
 		AWSSecretKey:     "345",
 		AWSSecurityToken: "567",
 		AWSSessionToken:  "567",
+		Expires:          time.Date(2016, 9, 4, 14, 27, 0, 0, time.UTC),
 	}
 
 	tests := []struct {
@@ -34,6 +36,7 @@ func TestBuildEnvVars(t *testing.T) {
 				"EC2_SECURITY_TOKEN=567",
 				"AWS_ACCESS_KEY_ID=123",
 				"AWS_SECRET_ACCESS_KEY=345",
+				"AWS_CREDENTIAL_EXPIRATION=2016-09-04T14:27:00Z",
 				"AWS_PROFILE=saml",
 				"AWS_DEFAULT_PROFILE=saml",
 			},
@@ -49,6 +52,7 @@ func TestBuildEnvVars(t *testing.T) {
 				"EC2_SECURITY_TOKEN=567",
 				"AWS_ACCESS_KEY_ID=123",
 				"AWS_SECRET_ACCESS_KEY=345",
+				"AWS_CREDENTIAL_EXPIRATION=2016-09-04T14:27:00Z",
 			},
 		},
 	}


### PR DESCRIPTION
This functionality allows for use cases such as creating custom
credential providers with botocore