### PR TITLE
Removes call to open FIDO device in Okta

### DIFF
--- a/pkg/provider/okta/okta_webauthn.go
+++ b/pkg/provider/okta/okta_webauthn.go
@@ -94,11 +94,6 @@ func (d *FidoClient) ChallengeU2F() (*SignedAssertion, error) {
 	interval := time.NewTicker(time.Millisecond * 250)
 	var responsePayload *SignedAssertion
 
-	err := d.Device.Open()
-	if err != nil {
-		return nil, errors.New("opening Device failed")
-	}
-
 	defer func() {
 		d.Device.Close()
 	}()


### PR DESCRIPTION
This is causing an error - apparently the call to `Open` was always returning an error and we were never checking it until you added the comment that checked for it here https://github.com/Versent/saml2aws/commit/e602111db872da7dd308f7ead7e70b18974642e7

Tested without and confirmed the call was unnecessary.