### PR TITLE
fix using exec-profile

### DIFF
--- a/cmd/saml2aws/commands/exec.go
+++ b/cmd/saml2aws/commands/exec.go
@@ -103,10 +103,16 @@ func assumeRoleWithProfile(targetProfile string, sessionDuration int) (*awsconfi
 	if err != nil {
 		return nil, err
 	}
+	expiredAt, err := sess.Config.Credentials.ExpiresAt()
+	if err != nil {
+		return nil, err
+	}
+
 	return &awsconfig.AWSCredentials{
 		AWSAccessKey:    creds.AccessKeyID,
 		AWSSecretKey:    creds.SecretAccessKey,
 		AWSSessionToken: creds.SessionToken,
+		Expires:         expiredAt,
 	}, nil
 }
 


### PR DESCRIPTION
After this commit (https://github.com/Versent/saml2aws/commit/2ace3880edd46109f6b425b06d384c9b22fee79d) the following error occurred only when using exec-profile

```
% saml2aws -a sample_idp exec --exec-profile=some-profile -- aws s3 ls
Credentials were refreshed, but the refreshed credentials are still expired.
exit status 255
```

I checked AWS_CREDENTIAL_EXPIRATION. Then, the zero value was set as follows.

```
% saml2aws -a sample_idp exec --exec-profile=some-profile -- bash -c "env | grep -i AWS_CREDENTIAL_EXPIRATION"
AWS_CREDENTIAL_EXPIRATION=0001-01-01T00:00:00Z
```

When modified like this branch, the following is modified and the command can be executed.
```
% ./saml2aws -a sample_idp exec --exec-profile=some-profile -- bash -c "env | grep -i AWS_CREDENTIAL_EXPIRATION"
AWS_CREDENTIAL_EXPIRATION=2020-02-03T07:20:09Z
```
