### PR TITLE
Increase waiting sleep for Okta Push to 3 seconds

### DIFF
--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -397,7 +397,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 			switch gjson.Get(string(body), "factorResult").String() {
 
 			case "WAITING":
-				time.Sleep(1000)
+				time.Sleep(3 * time.Second)
 				fmt.Printf(".")
 				logger.Debug("Waiting for user to authorize login")
 


### PR DESCRIPTION
In line with `IdentifierDuoMfa`:

https://github.com/Versent/saml2aws/blob/e602111db872da7dd308f7ead7e70b18974642e7/pkg/provider/okta/okta.go#L562

I've stumbled upon a problem (#429) where Okta Push MFA getting an error after 8 successful calls to API, which is with current timeouts is 800ms. With this change in place, I'll still get an error after 8 successful calls, but it will give me 24 seconds to push "Yes, it's me" button on my phone in the Okta app instead of current ~1 second.

Details of the problem are in the linked issue.