### PR TITLE
Remove glide from Appveyor

### DIFF
--- a/.appveyor/appveyor.yml
+++ b/.appveyor/appveyor.yml
@@ -20,8 +20,6 @@ install:
 
     $env:Path += ";`"$env:GOPATH\bin`";c:\go\bin;"
 
-    go get github.com/Masterminds/glide
-
     write-output $env:PATH
 
     go version


### PR DESCRIPTION
master build throws glide error at https://ci.appveyor.com/project/davidobrien1985/saml2aws/branch/master

I'm not sure how Appveyor is triggered