### PR TITLE
enable option to make login quiet

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 NAME=saml2aws
 ARCH=$(shell uname -m)
-VERSION=2.22.1
+VERSION=2.23.0
 ITERATION := 1
 
 SOURCE_FILES?=$$(go list ./... | grep -v /vendor/)

--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -10,7 +10,6 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
-
 	"github.com/versent/saml2aws"
 	"github.com/versent/saml2aws/helper/credentials"
 	"github.com/versent/saml2aws/pkg/awsconfig"
@@ -68,8 +67,9 @@ func Login(loginFlags *flags.LoginExecFlags) error {
 		return errors.Wrap(err, "error building IdP client")
 	}
 
-	fmt.Printf("Authenticating as %s ...\n", loginDetails.Username)
-
+	if !loginFlags.Quiet {
+		fmt.Printf("Authenticating as %s ...\n", loginDetails.Username)
+	}
 	samlAssertion, err := provider.Authenticate(loginDetails)
 	if err != nil {
 		return errors.Wrap(err, "error authenticating to IdP")
@@ -133,8 +133,9 @@ func resolveLoginDetails(account *cfg.IDPAccount, loginFlags *flags.LoginExecFla
 
 	loginDetails := &creds.LoginDetails{URL: account.URL, Username: account.Username, MFAToken: loginFlags.CommonFlags.MFAToken, DuoMFAOption: loginFlags.DuoMFAOption}
 
-	fmt.Printf("Using IDP Account %s to access %s %s\n", loginFlags.CommonFlags.IdpAccount, account.Provider, account.URL)
-
+	if !loginFlags.Quiet {
+		fmt.Printf("Using IDP Account %s to access %s %s\n", loginFlags.CommonFlags.IdpAccount, account.Provider, account.URL)
+	}
 	var err error
 	if !loginFlags.CommonFlags.DisableKeychain {
 		err = credentials.LookupCredentials(loginDetails, account.Provider)

--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -10,6 +10,7 @@ import (
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/versent/saml2aws"
 	"github.com/versent/saml2aws/helper/credentials"
 	"github.com/versent/saml2aws/pkg/awsconfig"
@@ -43,7 +44,9 @@ func Login(loginFlags *flags.LoginExecFlags) error {
 	}
 
 	if !sharedCreds.Expired() && !loginFlags.Force {
-		fmt.Println("credentials are not expired skipping")
+		if !loginFlags.Quiet {
+			fmt.Println("credentials are not expired skipping")
+		}
 		return nil
 	}
 

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/alecthomas/kingpin"
 	"github.com/sirupsen/logrus"
+
 	"github.com/versent/saml2aws/cmd/saml2aws/commands"
 	"github.com/versent/saml2aws/pkg/flags"
 )
@@ -86,6 +87,7 @@ func main() {
 	cmdLogin.Flag("client-id", "OneLogin client id, used to generate API access token. (env: ONELOGIN_CLIENT_ID)").Envar("ONELOGIN_CLIENT_ID").StringVar(&commonFlags.ClientID)
 	cmdLogin.Flag("client-secret", "OneLogin client secret, used to generate API access token. (env: ONELOGIN_CLIENT_SECRET)").Envar("ONELOGIN_CLIENT_SECRET").StringVar(&commonFlags.ClientSecret)
 	cmdLogin.Flag("force", "Refresh credentials even if not expired.").BoolVar(&loginFlags.Force)
+	cmdLogin.Flag("quiet", "Supress credentials not expired message").BoolVar(&loginFlags.Quiet)
 
 	// `exec` command and settings
 	cmdExec := app.Command("exec", "Exec the supplied command with env vars from STS token.")

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -32,6 +32,7 @@ type CommonFlags struct {
 type LoginExecFlags struct {
 	CommonFlags  *CommonFlags
 	Force        bool
+	Quiet        bool
 	DuoMFAOption string
 	ExecProfile  string
 }


### PR DESCRIPTION
This change allow to hidden the 'credentials are not expired skipping' message.

This is useful for me as I use the saml2aws in my oh-my-zsh setup everytime before I run a command, and if the credentials are expired, they will get updated. and the message above is a bit annoying to see in the prompt all the times.
