### PR TITLE
Set default to first item for role selection.

### DIFF
--- a/input.go
+++ b/input.go
@@ -101,7 +101,7 @@ func PromptForAWSRoleSelection(accounts []*AWSAccount) (*AWSRole, error) {
 
 	sort.Strings(roleOptions)
 
-	selectedRole, err := prompter.ChooseWithDefault("Please choose the role", "", roleOptions)
+	selectedRole, err := prompter.ChooseWithDefault("Please choose the role", roleOptions[0], roleOptions)
 	if err != nil {
 		return nil, errors.Wrap(err, "Role selection failed")
 	}


### PR DESCRIPTION
This fixes the issue: Selecting the first role does not work #421

This worked up to version 2.21.0 but was broken after that when you hit enter after showing the roles. You would have to hit the down and then up arrow to select the first item.

It does seem strange that this worked up till 2.21.1 version as I couldn't find anything merged that changed this code besides maybe this one: https://github.com/Versent/saml2aws/pull/402