### PR TITLE
Allow for govcloud saml redirect

### DIFF
--- a/aws_account.go
+++ b/aws_account.go
@@ -28,6 +28,10 @@ func ParseAWSAccounts(samlAssertion string) ([]*AWSAccount, error) {
 		fmt.Println("trying to login AWS China")
 		awsURL = "https://signin.amazonaws.cn/saml"
 	}
+	if strings.Contains(string(decSamlAssertion), "signin.amazonaws-us-gov.com") {
+		fmt.Println("trying to login AWS Govcloud")
+		awsURL = "https://signin.amazonaws-us-gov.com/saml"
+	}
 
 	res, err := http.PostForm(awsURL, url.Values{"SAMLResponse": {samlAssertion}})
 	if err != nil {

--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -4,8 +4,10 @@ import (
 	"encoding/base64"
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/endpoints"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/sts"
 	"github.com/pkg/errors"
@@ -242,12 +244,14 @@ func resolveRole(awsRoles []*saml2aws.AWSRole, samlAssertion string, account *cf
 }
 
 func loginToStsUsingRole(account *cfg.IDPAccount, role *saml2aws.AWSRole, samlAssertion string) (*awsconfig.AWSCredentials, error) {
-
 	sess, err := session.NewSession()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create session")
 	}
 
+	if strings.HasPrefix(role.RoleARN, "arn:aws-us-gov") {
+		sess.Config.WithRegion(endpoints.UsGovEast1RegionID)
+	}
 	svc := sts.New(sess)
 
 	params := &sts.AssumeRoleWithSAMLInput{


### PR DESCRIPTION
Currently the SAML use the default commercial partition for its calls.
This has the side-effect of preventing govcloud from working.
I used the fastest way to go there.

But we could parse the XML to use the saml2p:Response->Destination to use the correct target without having to rely on a `grep` of the content

And the region/partition could also be inferred in a similar way.