### PR TITLE
Print roles immediately if only one role in SAML assertion

### DIFF
--- a/cmd/saml2aws/commands/list_roles.go
+++ b/cmd/saml2aws/commands/list_roles.go
@@ -88,6 +88,15 @@ func ListRoles(loginFlags *flags.LoginExecFlags) error {
 }
 
 func listRoles(awsRoles []*saml2aws.AWSRole, samlAssertion string, loginFlags *flags.LoginExecFlags) error {
+	if len(awsRoles) == 1 {
+		fmt.Println("")
+		fmt.Println("Only one role to assume. Will be automatically assumed on login")
+		fmt.Println(awsRoles[0].RoleARN)
+		return nil
+	} else if len(awsRoles) == 0 {
+		return errors.New("no roles available")
+	}
+
 	awsAccounts, err := saml2aws.ParseAWSAccounts(samlAssertion)
 	if err != nil {
 		return errors.Wrap(err, "error parsing aws role accounts")


### PR DESCRIPTION
The "list-roles" command would always pass the assertion to AWS assuming it would receive the list of roles back and broke when there was only a single role to choose from, because AWS automatically redirects to the Console when there is only one role in the assertion.