### PR TITLE
Add console flag to present a link instead of opening browser directly

### DIFF
--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -97,11 +97,13 @@ func main() {
 
 	// `console` command and settings
 	cmdConsole := app.Command("console", "Console will open the aws console after logging in.")
-	consoleFlags := new(flags.LoginExecFlags)
-	consoleFlags.CommonFlags = commonFlags
-	cmdConsole.Flag("exec-profile", "The AWS profile to utilize for console execution. (env: SAML2AWS_EXEC_PROFILE)").Envar("SAML2AWS_EXEC_PROFILE").StringVar(&consoleFlags.ExecProfile)
+	consoleFlags := new(flags.ConsoleFlags)
+	consoleFlags.LoginExecFlags = execFlags
+	consoleFlags.LoginExecFlags.CommonFlags = commonFlags
+	cmdConsole.Flag("exec-profile", "The AWS profile to utilize for console execution. (env: SAML2AWS_EXEC_PROFILE)").Envar("SAML2AWS_EXEC_PROFILE").StringVar(&consoleFlags.LoginExecFlags.ExecProfile)
 	cmdConsole.Flag("profile", "The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)").Envar("SAML2AWS_PROFILE").Short('p').StringVar(&commonFlags.Profile)
-	cmdConsole.Flag("force", "Refresh credentials even if not expired.").BoolVar(&consoleFlags.Force)
+	cmdConsole.Flag("force", "Refresh credentials even if not expired.").BoolVar(&consoleFlags.LoginExecFlags.Force)
+	cmdConsole.Flag("link", "Present link to AWS console instead of opening browser").BoolVar(&consoleFlags.Link)
 
 	// `list` command and settings
 	cmdListRoles := app.Command("list-roles", "List available role ARNs.")

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -36,6 +36,11 @@ type LoginExecFlags struct {
 	ExecProfile  string
 }
 
+type ConsoleFlags struct {
+	LoginExecFlags *LoginExecFlags
+	Link           bool
+}
+
 // ApplyFlagOverrides overrides IDPAccount with command line settings
 func ApplyFlagOverrides(commonFlags *CommonFlags, account *cfg.IDPAccount) {
 	if commonFlags.AppID != "" {


### PR DESCRIPTION
This change makes it possible to present a link to aws console instead of opening a browser. If you run saml2aws in a headless vm / docker container you cant open the browser. You can then copy the link and open your browser on your host machine.

This is useful, when you use an windows developer machine with a ubuntu headless vagrant box for edititing code but you have no browser in the vm.