### PR TITLE
Fixes for okta + govcloud

### DIFF
--- a/aws_account.go
+++ b/aws_account.go
@@ -29,6 +29,11 @@ func ParseAWSAccounts(samlAssertion string) ([]*AWSAccount, error) {
 		awsURL = "https://signin.amazonaws.cn/saml"
 	}
 
+	if strings.Contains(string(decSamlAssertion), "signin.amazonaws-us-gov.com") {
+		fmt.Println("trying to login AWS GovCloud")
+		awsURL = "https://signin.amazonaws-us-gov.com/saml"
+	}
+
 	res, err := http.PostForm(awsURL, url.Values{"SAMLResponse": {samlAssertion}})
 	if err != nil {
 		return nil, errors.Wrap(err, "error retrieving AWS login form")

--- a/aws_account.go
+++ b/aws_account.go
@@ -29,11 +29,6 @@ func ParseAWSAccounts(samlAssertion string) ([]*AWSAccount, error) {
 		awsURL = "https://signin.amazonaws.cn/saml"
 	}
 
-	if strings.Contains(string(decSamlAssertion), "signin.amazonaws-us-gov.com") {
-		fmt.Println("trying to login AWS GovCloud")
-		awsURL = "https://signin.amazonaws-us-gov.com/saml"
-	}
-
 	res, err := http.PostForm(awsURL, url.Values{"SAMLResponse": {samlAssertion}})
 	if err != nil {
 		return nil, errors.Wrap(err, "error retrieving AWS login form")

--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -269,7 +269,17 @@ func docIsFormResume(doc *goquery.Document) bool {
 }
 
 func docIsFormRedirectToAWS(doc *goquery.Document) bool {
-	return doc.Find("form[action=\"https://signin.aws.amazon.com/saml\"]").Size() == 1
+	urls := []string{"form[action=\"https://signin.aws.amazon.com/saml\"]",
+			 "form[action=\"https://signin.amazonaws-us-gov.com/saml\"]",
+			 "form[action=\"https://signin.amazonaws.cn/saml\"]",
+		    };
+
+	for  _, value := range urls {
+		if (doc.Find(value).Size() > 0) {
+			return true
+		}
+	}
+	return false
 }
 
 func extractSAMLResponse(doc *goquery.Document) (v string, ok bool) {


### PR DESCRIPTION
Fixes #475.

Added the known SAML signin pages for the AWS GovCloud (US) and AWS China into the okta provider, as well as into the SAML assertion parser.

Note this may not be good, idiomatic golang...  Sorry, my first attempt at doing something with it.