### PR TITLE
Make `config` flag global

### DIFF
--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -103,7 +103,7 @@ func Login(loginFlags *flags.LoginExecFlags) error {
 }
 
 func buildIdpAccount(loginFlags *flags.LoginExecFlags) (*cfg.IDPAccount, error) {
-	cfgm, err := cfg.NewConfigManager(cfg.DefaultConfigPath)
+	cfgm, err := cfg.NewConfigManager(loginFlags.CommonFlags.ConfigFile)
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to load configuration")
 	}

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -52,6 +52,7 @@ func main() {
 
 	// Common (to all commands) settings
 	commonFlags := new(flags.CommonFlags)
+	app.Flag("config", "Path/filename of saml2aws config file (env: SAML2AWS_CONFIGFILE)").Envar("SAML2AWS_CONFIGFILE").StringVar(&commonFlags.ConfigFile)
 	app.Flag("idp-account", "The name of the configured IDP account. (env: SAML2AWS_IDP_ACCOUNT)").Envar("SAML2AWS_IDP_ACCOUNT").Short('a').Default("default").StringVar(&commonFlags.IdpAccount)
 	app.Flag("idp-provider", "The configured IDP provider. (env: SAML2AWS_IDP_PROVIDER)").Envar("SAML2AWS_IDP_PROVIDER").EnumVar(&commonFlags.IdpProvider, "Akamai", "AzureAD", "ADFS", "ADFS2", "GoogleApps", "Ping", "JumpCloud", "Okta", "OneLogin", "PSU", "KeyCloak", "F5APM", "Shibboleth", "ShibbolethECP", "NetIQ")
 	app.Flag("mfa", "The name of the mfa. (env: SAML2AWS_MFA)").Envar("SAML2AWS_MFA").StringVar(&commonFlags.MFA)
@@ -74,7 +75,6 @@ func main() {
 	cmdConfigure.Flag("subdomain", "OneLogin subdomain of your company account. (env: ONELOGIN_SUBDOMAIN)").Envar("ONELOGIN_SUBDOMAIN").StringVar(&commonFlags.Subdomain)
 	cmdConfigure.Flag("profile", "The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)").Envar("SAML2AWS_PROFILE").Short('p').StringVar(&commonFlags.Profile)
 	cmdConfigure.Flag("resource-id", "F5APM SAML resource ID of your company account. (env: SAML2AWS_F5APM_RESOURCE_ID)").Envar("SAML2AWS_F5APM_RESOURCE_ID").StringVar(&commonFlags.ResourceID)
-	cmdConfigure.Flag("config", "Path/filename of saml2aws config file (env: SAML2AWS_CONFIGFILE)").Envar("SAML2AWS_CONFIGFILE").StringVar(&commonFlags.ConfigFile)
 	configFlags := commonFlags
 
 	// `login` command and settings


### PR DESCRIPTION
I was surprised to discover that `--config` flag and `SAML2AWS_CONFIGFILE` env var was only respected by `configure` subcommand, so I fixed it by making the flag global.

Please let me know if I misunderstood or missed something.

Thanks!