### PR TITLE
Get the AWS destination from the Destination, not Audience

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Flags:
       --verbose                Enable verbose logging
   -i, --provider=PROVIDER      This flag is obsolete. See: https://github.com/Versent/saml2aws#configuring-idp-accounts
   -a, --idp-account="default"  The name of the configured IDP account. (env: SAML2AWS_IDP_ACCOUNT)
-      --idp-provider=IDP-PROVIDER  
+      --idp-provider=IDP-PROVIDER
                                The configured IDP provider. (env: SAML2AWS_IDP_PROVIDER)
       --mfa=MFA                The name of the mfa. (env: SAML2AWS_MFA)
   -s, --skip-verify            Skip verification of server certificate. (env: SAML2AWS_SKIP_VERIFY)
@@ -132,9 +132,10 @@ Flags:
       --role=ROLE              The ARN of the role to assume. (env: SAML2AWS_ROLE)
       --aws-urn=AWS-URN        The URN used by SAML when you login. (env: SAML2AWS_AWS_URN)
       --skip-prompt            Skip prompting for parameters during login.
-      --session-duration=SESSION-DURATION  
+      --session-duration=SESSION-DURATION
                                The duration of your AWS Session. (env: SAML2AWS_SESSION_DURATION)
       --disable-keychain       Do not use keychain at all.
+  -r, --region="us-east-1"     AWS region to use for API requests (env: SAML2AWS_REGION)
 
 Commands:
   help [<command>...]
@@ -146,7 +147,7 @@ Commands:
 
         --app-id=APP-ID            OneLogin app id required for SAML assertion. (env: ONELOGIN_APP_ID)
         --client-id=CLIENT-ID      OneLogin client id, used to generate API access token. (env: ONELOGIN_CLIENT_ID)
-        --client-secret=CLIENT-SECRET  
+        --client-secret=CLIENT-SECRET
                                    OneLogin client secret, used to generate API access token. (env: ONELOGIN_CLIENT_SECRET)
         --subdomain=SUBDOMAIN      OneLogin subdomain of your company account. (env: ONELOGIN_SUBDOMAIN)
     -p, --profile=PROFILE          The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)
@@ -157,10 +158,10 @@ Commands:
     Login to a SAML 2.0 IDP and convert the SAML assertion to an STS token.
 
     -p, --profile=PROFILE      The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)
-        --duo-mfa-option=DUO-MFA-OPTION  
+        --duo-mfa-option=DUO-MFA-OPTION
                                The MFA option you want to use to authenticate with
         --client-id=CLIENT-ID  OneLogin client id, used to generate API access token. (env: ONELOGIN_CLIENT_ID)
-        --client-secret=CLIENT-SECRET  
+        --client-secret=CLIENT-SECRET
                                OneLogin client secret, used to generate API access token. (env: ONELOGIN_CLIENT_SECRET)
         --force                Refresh credentials even if not expired.
 
@@ -168,13 +169,14 @@ Commands:
     Exec the supplied command with env vars from STS token.
 
     -p, --profile=PROFILE  The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)
-        --exec-profile=EXEC-PROFILE  
-                           The AWS profile to utilize for command execution. Useful to allow the aws cli to perform secondary role assumption. (env:
-                           SAML2AWS_EXEC_PROFILE)
+        --exec-profile=EXEC-PROFILE
+                           The AWS profile to utilize for command execution. Useful to allow the aws cli to perform secondary role assumption. (env: SAML2AWS_EXEC_PROFILE)
 
   console [<flags>]
     Console will open the aws console after logging in.
 
+        --exec-profile=EXEC-PROFILE
+                           The AWS profile to utilize for console execution. (env: SAML2AWS_EXEC_PROFILE)
     -p, --profile=PROFILE  The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)
         --force            Refresh credentials even if not expired.
 
@@ -257,6 +259,7 @@ account {
   AmazonWebservicesURN: urn:amazon:webservices
   SessionDuration: 3600
   Profile: myaccount
+  Region: us-east-1
 }
 
 Configuration saved for IDP account: default
@@ -277,7 +280,7 @@ saml2aws configure -a wolfeidau
 You can also configure the account alias without prompts.
 
 ```
-saml2aws configure -a wolfeidau --idp-provider KeyCloak --username mark@wolfe.id.au \
+saml2aws configure -a wolfeidau --idp-provider KeyCloak --username mark@wolfe.id.au -r cn-north-1  \
   --url https://keycloak.wolfe.id.au/auth/realms/master/protocol/saml/clients/amazon-aws --skip-prompt
 ```
 
@@ -353,6 +356,7 @@ aws_urn                 = urn:amazon:webservices
 aws_session_duration    = 28800
 aws_profile             = customer-dev
 role_arn                = arn:aws:iam::121234567890:role/customer-admin-role
+region                  = us-east-1
 ```
 
 To use this you will need to export `AWS_DEFAULT_PROFILE=customer-dev` environment variable to target `dev`.
@@ -379,6 +383,7 @@ aws_urn                 = urn:amazon:webservices
 aws_session_duration    = 28800
 aws_profile             = customer-test
 role_arn                = arn:aws:iam::121234567891:role/customer-admin-role
+region                  = us-east-1
 ```
 
 To use this you will need to export `AWS_DEFAULT_PROFILE=customer-test` environment variable to target `test`.
@@ -492,6 +497,7 @@ There are few additional parameters allowing to customise saml2aws configuration
 Use following parameters in `~/.saml2aws` file:
 - `http_attempts_count` - configures the number of attempts to send http requests in order to authorise with saml provider. Defaults to 1
 - `http_retry_delay` - configures the duration (in seconds) of timeout between attempts to send http requests to saml provider. Defaults to 1
+- `region` - configures which region endpoints to use, See [Audience](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html#saml_audience-restriction) and [partition](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax), Defaults to `us-east-1`
 
 Example: typical configuration with such parameters would look like follows:
 ```
@@ -508,6 +514,7 @@ aws_profile             = customer-dev
 role_arn                = arn:aws:iam::121234567890:role/customer-admin-role
 http_attempts_count     = 3
 http_retry_delay        = 1
+region                  = us-east-1
 ```
 ## Building
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Flags:
       --session-duration=SESSION-DURATION
                                The duration of your AWS Session. (env: SAML2AWS_SESSION_DURATION)
       --disable-keychain       Do not use keychain at all.
-  -r, --region="us-east-1"     AWS region to use for API requests, e.g. us-east-1, us-gov-west-1, cn-north-1 (env: SAML2AWS_REGION)
+  -r, --region=REGION          AWS region to use for API requests, e.g. us-east-1, us-gov-west-1, cn-north-1 (env: SAML2AWS_REGION)
 
 Commands:
   help [<command>...]

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Flags:
       --session-duration=SESSION-DURATION
                                The duration of your AWS Session. (env: SAML2AWS_SESSION_DURATION)
       --disable-keychain       Do not use keychain at all.
-  -r, --region="us-east-1"     AWS region to use for API requests (env: SAML2AWS_REGION)
+  -r, --region="us-east-1"     AWS region to use for API requests, e.g. us-east-1, us-gov-west-1, cn-north-1 (env: SAML2AWS_REGION)
 
 Commands:
   help [<command>...]

--- a/README.md
+++ b/README.md
@@ -497,7 +497,7 @@ There are few additional parameters allowing to customise saml2aws configuration
 Use following parameters in `~/.saml2aws` file:
 - `http_attempts_count` - configures the number of attempts to send http requests in order to authorise with saml provider. Defaults to 1
 - `http_retry_delay` - configures the duration (in seconds) of timeout between attempts to send http requests to saml provider. Defaults to 1
-- `region` - configures which region endpoints to use, See [Audience](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html#saml_audience-restriction) and [partition](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax), Defaults to `us-east-1`
+- `region` - configures which region endpoints to use, See [Audience](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html#saml_audience-restriction) and [partition](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax)
 
 Example: typical configuration with such parameters would look like follows:
 ```

--- a/aws_account.go
+++ b/aws_account.go
@@ -2,18 +2,14 @@ package saml2aws
 
 import (
 	"bytes"
-	b64 "encoding/base64"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/pkg/errors"
 )
-
-var awsURL = "https://signin.aws.amazon.com/saml"
 
 // AWSAccount holds the AWS account name and roles
 type AWSAccount struct {
@@ -22,14 +18,8 @@ type AWSAccount struct {
 }
 
 // ParseAWSAccounts extract the aws accounts from the saml assertion
-func ParseAWSAccounts(samlAssertion string) ([]*AWSAccount, error) {
-	decSamlAssertion, _ := b64.StdEncoding.DecodeString(samlAssertion)
-	if strings.Contains(string(decSamlAssertion), "signin.amazonaws.cn") {
-		fmt.Println("trying to login AWS China")
-		awsURL = "https://signin.amazonaws.cn/saml"
-	}
-
-	res, err := http.PostForm(awsURL, url.Values{"SAMLResponse": {samlAssertion}})
+func ParseAWSAccounts(audience string, samlAssertion string) ([]*AWSAccount, error) {
+	res, err := http.PostForm(audience, url.Values{"SAMLResponse": {samlAssertion}})
 	if err != nil {
 		return nil, errors.Wrap(err, "error retrieving AWS login form")
 	}

--- a/cmd/saml2aws/commands/list_roles.go
+++ b/cmd/saml2aws/commands/list_roles.go
@@ -102,7 +102,7 @@ func listRoles(awsRoles []*saml2aws.AWSRole, samlAssertion string, loginFlags *f
 		return errors.Wrap(err, "error decoding saml assertion")
 	}
 
-	aud, err := saml2aws.ExtractAudienceURL(samlAssertionData)
+	aud, err := saml2aws.ExtractDestinationURL(samlAssertionData)
 	if err != nil {
 		return errors.Wrap(err, "error parsing destination url")
 	}

--- a/cmd/saml2aws/commands/list_roles.go
+++ b/cmd/saml2aws/commands/list_roles.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"encoding/base64"
+	b64 "encoding/base64"
 	"fmt"
 	"os"
 
@@ -60,7 +60,7 @@ func ListRoles(loginFlags *flags.LoginExecFlags) error {
 		}
 	}
 
-	data, err := base64.StdEncoding.DecodeString(samlAssertion)
+	data, err := b64.StdEncoding.DecodeString(samlAssertion)
 	if err != nil {
 		return errors.Wrap(err, "error decoding saml assertion")
 	}
@@ -97,7 +97,17 @@ func listRoles(awsRoles []*saml2aws.AWSRole, samlAssertion string, loginFlags *f
 		return errors.New("no roles available")
 	}
 
-	awsAccounts, err := saml2aws.ParseAWSAccounts(samlAssertion)
+	samlAssertionData, err := b64.StdEncoding.DecodeString(samlAssertion)
+	if err != nil {
+		return errors.Wrap(err, "error decoding saml assertion")
+	}
+
+	aud, err := saml2aws.ExtractAudienceURL(samlAssertionData)
+	if err != nil {
+		return errors.Wrap(err, "error parsing destination url")
+	}
+
+	awsAccounts, err := saml2aws.ParseAWSAccounts(aud, samlAssertion)
 	if err != nil {
 		return errors.Wrap(err, "error parsing aws role accounts")
 	}

--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -221,7 +221,7 @@ func resolveRole(awsRoles []*saml2aws.AWSRole, samlAssertion string, account *cf
 		return nil, errors.Wrap(err, "error decoding saml assertion")
 	}
 
-	aud, err := saml2aws.ExtractAudienceURL(samlAssertionData)
+	aud, err := saml2aws.ExtractDestinationURL(samlAssertionData)
 	if err != nil {
 		return nil, errors.Wrap(err, "error parsing destination url")
 	}

--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -1,7 +1,7 @@
 package commands
 
 import (
-	"encoding/base64"
+	b64 "encoding/base64"
 	"fmt"
 	"os"
 
@@ -180,7 +180,7 @@ func resolveLoginDetails(account *cfg.IDPAccount, loginFlags *flags.LoginExecFla
 }
 
 func selectAwsRole(samlAssertion string, account *cfg.IDPAccount) (*saml2aws.AWSRole, error) {
-	data, err := base64.StdEncoding.DecodeString(samlAssertion)
+	data, err := b64.StdEncoding.DecodeString(samlAssertion)
 	if err != nil {
 		return nil, errors.Wrap(err, "error decoding saml assertion")
 	}
@@ -216,7 +216,17 @@ func resolveRole(awsRoles []*saml2aws.AWSRole, samlAssertion string, account *cf
 		return nil, errors.New("no roles available")
 	}
 
-	awsAccounts, err := saml2aws.ParseAWSAccounts(samlAssertion)
+	samlAssertionData, err := b64.StdEncoding.DecodeString(samlAssertion)
+	if err != nil {
+		return nil, errors.Wrap(err, "error decoding saml assertion")
+	}
+
+	aud, err := saml2aws.ExtractAudienceURL(samlAssertionData)
+	if err != nil {
+		return nil, errors.Wrap(err, "error parsing destination url")
+	}
+
+	awsAccounts, err := saml2aws.ParseAWSAccounts(aud, samlAssertion)
 	if err != nil {
 		return nil, errors.Wrap(err, "error parsing aws role accounts")
 	}
@@ -243,7 +253,9 @@ func resolveRole(awsRoles []*saml2aws.AWSRole, samlAssertion string, account *cf
 
 func loginToStsUsingRole(account *cfg.IDPAccount, role *saml2aws.AWSRole, samlAssertion string) (*awsconfig.AWSCredentials, error) {
 
-	sess, err := session.NewSession()
+	sess, err := session.NewSession(&aws.Config{
+		Region: &account.Region,
+	})
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to create session")
 	}

--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -283,6 +283,7 @@ func loginToStsUsingRole(account *cfg.IDPAccount, role *saml2aws.AWSRole, samlAs
 		AWSSecurityToken: aws.StringValue(resp.Credentials.SessionToken),
 		PrincipalARN:     aws.StringValue(resp.AssumedRoleUser.Arn),
 		Expires:          resp.Credentials.Expiration.Local(),
+		Region:           account.Region,
 	}, nil
 }
 

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -65,6 +65,7 @@ func main() {
 	app.Flag("skip-prompt", "Skip prompting for parameters during login.").BoolVar(&commonFlags.SkipPrompt)
 	app.Flag("session-duration", "The duration of your AWS Session. (env: SAML2AWS_SESSION_DURATION)").Envar("SAML2AWS_SESSION_DURATION").IntVar(&commonFlags.SessionDuration)
 	app.Flag("disable-keychain", "Do not use keychain at all.").Envar("SAML2AWS_DISABLE_KEYCHAIN").BoolVar(&commonFlags.DisableKeychain)
+	app.Flag("region", "AWS region to use for API requests (env: SAML2AWS_REGION)").Envar("SAML2AWS_REGION").Short('r').Default("us-east-1").StringVar(&commonFlags.Region)
 
 	// `configure` command and settings
 	cmdConfigure := app.Command("configure", "Configure a new IDP account.")

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -65,7 +65,7 @@ func main() {
 	app.Flag("skip-prompt", "Skip prompting for parameters during login.").BoolVar(&commonFlags.SkipPrompt)
 	app.Flag("session-duration", "The duration of your AWS Session. (env: SAML2AWS_SESSION_DURATION)").Envar("SAML2AWS_SESSION_DURATION").IntVar(&commonFlags.SessionDuration)
 	app.Flag("disable-keychain", "Do not use keychain at all.").Envar("SAML2AWS_DISABLE_KEYCHAIN").BoolVar(&commonFlags.DisableKeychain)
-	app.Flag("region", "AWS region to use for API requests (env: SAML2AWS_REGION)").Envar("SAML2AWS_REGION").Short('r').Default("us-east-1").StringVar(&commonFlags.Region)
+	app.Flag("region", "AWS region to use for API requests, e.g. us-east-1, us-gov-west-1, cn-north-1 (env: SAML2AWS_REGION)").Envar("SAML2AWS_REGION").Short('r').Default("us-east-1").StringVar(&commonFlags.Region)
 
 	// `configure` command and settings
 	cmdConfigure := app.Command("configure", "Configure a new IDP account.")

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -65,7 +65,7 @@ func main() {
 	app.Flag("skip-prompt", "Skip prompting for parameters during login.").BoolVar(&commonFlags.SkipPrompt)
 	app.Flag("session-duration", "The duration of your AWS Session. (env: SAML2AWS_SESSION_DURATION)").Envar("SAML2AWS_SESSION_DURATION").IntVar(&commonFlags.SessionDuration)
 	app.Flag("disable-keychain", "Do not use keychain at all.").Envar("SAML2AWS_DISABLE_KEYCHAIN").BoolVar(&commonFlags.DisableKeychain)
-	app.Flag("region", "AWS region to use for API requests, e.g. us-east-1, us-gov-west-1, cn-north-1 (env: SAML2AWS_REGION)").Envar("SAML2AWS_REGION").Short('r').Default("us-east-1").StringVar(&commonFlags.Region)
+	app.Flag("region", "AWS region to use for API requests, e.g. us-east-1, us-gov-west-1, cn-north-1 (env: SAML2AWS_REGION)").Envar("SAML2AWS_REGION").Short('r').StringVar(&commonFlags.Region)
 
 	// `configure` command and settings
 	cmdConfigure := app.Command("configure", "Configure a new IDP account.")

--- a/pkg/awsconfig/awsconfig.go
+++ b/pkg/awsconfig/awsconfig.go
@@ -34,6 +34,7 @@ type AWSCredentials struct {
 	AWSSecurityToken string    `ini:"aws_security_token"`
 	PrincipalARN     string    `ini:"x_principal_arn"`
 	Expires          time.Time `ini:"x_security_token_expires"`
+	Region           string    `ini:"region"`
 }
 
 // CredentialsProvider loads aws credentials file

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -43,6 +43,7 @@ type IDPAccount struct {
 	ResourceID           string `ini:"resource_id"` // used by F5APM
 	Subdomain            string `ini:"subdomain"`   // used by OneLogin
 	RoleARN              string `ini:"role_arn"`
+	Region               string `ini:"region"`
 	HttpAttemptsCount    string `ini:"http_attempts_count"`
 	HttpRetryDelay       string `ini:"http_retry_delay"`
 }
@@ -72,7 +73,8 @@ func (ia IDPAccount) String() string {
   SessionDuration: %d
   Profile: %s
   RoleARN: %s
-}`, appID, policyID, ia.URL, ia.Username, ia.Provider, ia.MFA, ia.SkipVerify, ia.AmazonWebservicesURN, ia.SessionDuration, ia.Profile, ia.RoleARN)
+  Region: %s
+}`, appID, policyID, ia.URL, ia.Username, ia.Provider, ia.MFA, ia.SkipVerify, ia.AmazonWebservicesURN, ia.SessionDuration, ia.Profile, ia.RoleARN, ia.Region)
 }
 
 // Validate validate the required / expected fields are set

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -26,6 +26,7 @@ type CommonFlags struct {
 	Subdomain            string
 	ResourceID           string
 	DisableKeychain      bool
+	Region               string
 }
 
 // LoginExecFlags flags for the Login / Exec commands
@@ -83,5 +84,8 @@ func ApplyFlagOverrides(commonFlags *CommonFlags, account *cfg.IDPAccount) {
 	}
 	if commonFlags.ResourceID != "" {
 		account.ResourceID = commonFlags.ResourceID
+	}
+	if commonFlags.Region != "" {
+		account.Region = commonFlags.Region
 	}
 }

--- a/saml.go
+++ b/saml.go
@@ -12,6 +12,7 @@ const (
 	attributeStatementTag = "AttributeStatement"
 	attributeTag          = "Attribute"
 	attributeValueTag     = "AttributeValue"
+	audienceTag           = "Audience"
 )
 
 //ErrMissingElement is the error type that indicates an element and/or attribute is
@@ -69,6 +70,23 @@ func ExtractSessionDuration(data []byte) (int64, error) {
 	}
 
 	return 0, nil
+}
+
+// ExtractDestinationURL will find the Destination URL to POST the SAML assertion to.
+// This is necessary to support AWS instances with custom endpoints such as GovCloud and AWS China without requiring
+// hardcoded endpoints on the saml2aws side.
+func ExtractAudienceURL(data []byte) (string, error) {
+	doc := etree.NewDocument()
+	if err := doc.ReadFromBytes(data); err != nil {
+		return "", err
+	}
+
+	audienceElement := doc.FindElement(".//Audience")
+	if audienceElement == nil {
+		return "", ErrMissingElement{Tag: audienceTag}
+	}
+
+	return audienceElement.Text(), nil
 }
 
 // ExtractAwsRoles given an assertion document extract the aws roles


### PR DESCRIPTION
Additional work on top of #469 to support how Okta's SAML response is formatted.  Okta returns the `Audience` as `urn:amazon:webservices` which is not that useful.   So this updates to grab the `Destination` attribute of the root element of the SAML response.