### PR TITLE
fix script's template for powershell

### DIFF
--- a/cmd/saml2aws/commands/script.go
+++ b/cmd/saml2aws/commands/script.go
@@ -32,7 +32,7 @@ $env:AWS_SECRET_ACCESS_KEY='{{ .AWSSecretKey }}'
 $env:AWS_SESSION_TOKEN='{{ .AWSSessionToken }}'
 $env:AWS_SECURITY_TOKEN='{{ .AWSSecurityToken }}'
 $env:SAML2AWS_PROFILE='{{ .ProfileName }}'
-$env:AWS_CREDENTIAL_EXPIRATION='{{ .Expires "2006-01-02T15:04:05Z07:00" }}'
+$env:AWS_CREDENTIAL_EXPIRATION='{{ .Expires.Format "2006-01-02T15:04:05Z07:00" }}'
 `
 
 // Script will emit a bash script that will export environment variables


### PR DESCRIPTION
same as https://github.com/Versent/saml2aws/issues/471 but for powershell

`saml2aws.exe script --shell=powershell`
// snip
`$env:AWS_CREDENTIAL_EXPIRATION='error generating template: template: envvar_script:6:35: executing "envvar_script" at <.Expires>: Expires has arguments but cannot be invoked as function`