### PR TITLE
Fix use of OKTA (Okta verify TOTP) as an MFA provider setting

### DIFF
--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -294,7 +294,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 
 	if strings.ToUpper(oc.mfa) != "AUTO" {
 		for idx, val := range mfaOptions {
-			if strings.HasPrefix(val, oc.mfa) {
+			if strings.HasPrefix(strings.ToUpper(val), oc.mfa) {
 				mfaOption = idx
 				break
 			}


### PR DESCRIPTION
Saml2aws compares the configured MFA factor (with --mfa or the MFA
configuration option) with the display name of the availabile factors.
For the Okta Verify TOTP factor, the display name is "Okta MFA
Authentication", but the allowed configuration option is "OKTA", and so
when you set --mfa=OKTA (or the equivalent in the configuration file),
it doesn't match, and you get a push notification from Okta Verify
instead.

This change just makes the prefix comparison case insensitive, so
setting `--mfa=OKTA` will match the "Okta MFA Authentication" option,
and you are prompted for a TOTP code from the Okta Verify app.

Alternative fixes could be changing the display name to 'OKTA MFA Authentication', or allowing 'Okta' to be the entry specified on the command line, but the latter is inconsistent with the other configuration options and the former means the display name will look awkward.