### PR TITLE
Correct end index when extracting JSON from login response

### DIFF
--- a/pkg/provider/aad/aad.go
+++ b/pkg/provider/aad/aad.go
@@ -699,7 +699,7 @@ func (ac *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 	var loginPasswordJson string
 	if strings.Contains(resBodyStr, "$Config") {
 		startIndex := strings.Index(resBodyStr, "$Config=") + 8
-		endIndex := startIndex + strings.Index(resBodyStr[startIndex:], ";")
+		endIndex := startIndex + strings.Index(resBodyStr[startIndex:], "\n") - 1
 		loginPasswordJson = resBodyStr[startIndex:endIndex]
 	}
 	var loginPasswordResp passwordLoginResponse


### PR DESCRIPTION
Semicolon can show up as a character in the response and not signify end of statement.

For example, on my company's Azure login I get this in the response:
```
$Config={... "Illustration":"https://aadcdn.msauthimages.net/c1c6b6c8-ujbrmqystroz2zskhz5wa4ahmdyaiqbvcjcapkylqvg/logintenantbranding/0/illustration?ts=636978528194440357","BoilerPlateText":"Please use your Azure username to sign in. \n\nAttention: Your Azure password is different from your Gmail password. Azure and Gmail are different user accounts with each their own credentials (it just so happens that Azure username and Gmail have the same format).\n\nA strong password complies with the following:\n- A minimum of 8 characters \n- Requires three out of four of the following:\nLowercase characters.\nUppercase characters.\nNumbers (0-9).\nSymbols (@ # $ % ^ &amp; * - _ ! + = [ ] { } | \\ : ‘ , . ? / ` ~ &quot; ( ) ;)","UserIdLabel":"Please use your Azure username to sign in ","KeepMeSignedInDisabled":true,"UseTransparentLightBox":false}] ...};
```

Using a new line fixes this issue as it matches literal newline character and not an escaped one, as seen in the example above.