### PR TITLE
[Azure AD] Revert #435 for #464 fix

### DIFF
--- a/pkg/provider/aad/aad.go
+++ b/pkg/provider/aad/aad.go
@@ -842,6 +842,39 @@ func (ac *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 		if err != nil {
 			return samlAssertion, errors.Wrap(err, "error retrieving process auth results")
 		}
+		// data is embeded javascript object
+		// <script><![CDATA[  $Config=......; ]]>
+		resBody, _ = ioutil.ReadAll(res.Body)
+		resBodyStr = string(resBody)
+
+		var ProcessAuthJson string
+		if strings.Contains(resBodyStr, "$Config") {
+			startIndex := strings.Index(resBodyStr, "$Config=") + 8
+			endIndex := startIndex + strings.Index(resBodyStr[startIndex:], ";")
+			ProcessAuthJson = resBodyStr[startIndex:endIndex]
+		}
+		var processAuthResp processAuthResponse
+		if err := json.Unmarshal([]byte(ProcessAuthJson), &processAuthResp); err != nil {
+			return samlAssertion, errors.Wrap(err, "ProcessAuth response unmarshal error")
+		}
+
+		// After performing MFA we'll always be prompted with KMSI (Keep Me Signed In) page
+		KmsiURL := res.Request.URL.Scheme + "://" + res.Request.URL.Host + processAuthResp.URLPost
+		KmsiValues := url.Values{}
+		KmsiValues.Set("flowToken", processAuthResp.SFT)
+		KmsiValues.Set("ctx", processAuthResp.SCtx)
+		KmsiValues.Set("LoginOptions", "1")
+		KmsiRequest, err := http.NewRequest("POST", KmsiURL, strings.NewReader(KmsiValues.Encode()))
+		if err != nil {
+			return samlAssertion, errors.Wrap(err, "error retrieving kmsi results")
+		}
+		KmsiRequest.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		ac.client.DisableFollowRedirect()
+		res, err = ac.client.Do(KmsiRequest)
+		if err != nil {
+			return samlAssertion, errors.Wrap(err, "error retrieving kmsi results")
+		}
+		ac.client.EnableFollowRedirect()
 	} else {
 		// There was no explicit link to skip MFA
 		// and there were no MFA options available for us to process


### PR DESCRIPTION
## The reason for the problem

In the MFA of Azure AD, the KMSI page is always displayed. 
To solve the problem, we need to get the `authSubmitURL` by using the response body of the KMSI page. 

It seems that `saml2aws` expects the specification for the response body below: https://github.com/Versent/saml2aws/blob/8a75db809a21ce7d412b64d3b7e1db593a5d6db6/pkg/provider/aad/aad.go#L885-L895
https://github.com/Versent/saml2aws/blob/8a75db809a21ce7d412b64d3b7e1db593a5d6db6/pkg/provider/aad/aad.go#L897-L903

In fact, we get a HTML as the response body like:
<details><summary>an example response body of <code>loginPasswordResp.URLPost</code></summary>

```html
<!-- Copyright (C) Microsoft Corporation. All rights reserved. -->
<!DOCTYPE html>
<html dir="ltr" class="" lang="en">
<head>
    <title>Sign in to your account</title>
    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
    <meta http-equiv="X-UA-Compatible" content="IE=edge">
    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=2.0, user-scalable=yes">
    <meta http-equiv="Pragma" content="no-cache">
    <meta http-equiv="Expires" content="-1">
    <link rel="preconnect" href="https://aadcdn.msauth.net" crossorigin>
    <meta http-equiv="x-dns-prefetch-control" content="on">
    <link rel="dns-prefetch" href="//aadcdn.msauth.net">
    <link rel="dns-prefetch" href="//aadcdn.msftauth.net">
    <meta name="PageID" content="ConvergedTFA" />
    <meta name="SiteID" content="" />
    <meta name="ReqLC" content="1033" />
    <meta name="LocLC" content="en-US" />
    <meta name="referrer" content="origin" />
    <noscript>
        <meta http-equiv="Refresh" content="0; URL=https://login.microsoftonline.com/jsdisabled" />
    </noscript>
    <meta name="robots" content="none" />

    <script type="text/javascript">
        //<![CDATA[
        $Config = {
            "arrUserProofs": [{
                "authMethodId": "PhoneAppNotification",
                "data": "PhoneAppNotification",
                "display": "",
                "isDefault": true
            }, {
                "authMethodId": "PhoneAppOTP",
                "data": "PhoneAppOTP",
                "display": "",
                "isDefault": false
            }],
            "fHideIHaveCodeLink": true,
            "oPerAuthPollingInterval": {
                "PhoneAppNotification": 1.0
            },
            "fProofIndexedByType": true,
            "urlBeginAuth": "https://login.microsoftonline.com/common/SAS/BeginAuth",
            "urlEndAuth": "https://login.microsoftonline.com/common/SAS/EndAuth",
            "iSAMode": 2,
            "iTrustedDeviceCheckboxConfig": 3,
            "iMaxPollAttempts": 10,
            "iPollingTimeout": 120000,
            "iPollingBackoffInterval": 1.04,
            "iRememberMfaDuration": 30.0,
            "sTrustedDeviceCheckboxName": "rememberMFA",
            "sAuthMethodInputFieldName": "mfaAuthMethod",
            "iSAOtcLength": 6,
            "iTotpOtcLength": 6,
            "urlMoreInfo": "https://go.microsoft.com/fwlink/p/?LinkId=708614",
            "fShowViewDetailsLink": true,
            "iMaxStackForKnockoutAsyncComponents": 10000,
            "fShowButtons": true,
            "urlCdn": "https://aadcdn.msauth.net/ests/2.1/",
            "urlFooterTOU": "https://www.microsoft.com/en-US/servicesagreement/",
            "urlFooterPrivacy": "https://privacy.microsoft.com/en-US/privacystatement",
            "urlPost": "https://login.microsoftonline.com/common/SAS/ProcessAuth",
            "urlCancel": "https://login.microsoftonline.com/common/reprocess?xxxx",
            "iPawnIcon": 0,
            "iPollingInterval": 5000,
            "sPOST_Username": "kenchan0130@example.com",
            "sFT": "xxxx",
            "sFTName": "flowToken",
            "sCtx": "xxxx2",
            "dynamicTenantBranding": [{
                "Locale": 0,
                "Illustration": "https://secure.aadcdn.microsoftonline-p.com/dbd5a2dd-0fygp6kcthpce-epzigh54nfgbgjbantgxonhl-nju/logintenantbranding/0/illustration?ts=636737492978973081",
                "UserIdLabel": "someone@example.com",
                "KeepMeSignedInDisabled": false,
                "UseTransparentLightBox": false
            }],
            "staticTenantBranding": null,
            "oAppCobranding": {},
            "iBackgroundImage": 2,
            "fApplicationInsightsEnabled": false,
            "iApplicationInsightsEnabledPercentage": 0,
            "urlSetDebugMode": "https://login.microsoftonline.com/common/debugmode",
            "fEnableCssAnimation": true,
            "fAllowGrayOutLightBox": true,
            "fIsRemoteNGCSupported": true,
            "fUseSameSite": true,
            "isGlobalTenant": true,
            "fUseNewDefaultBackgroundImage": true,
            "scid": 5005,
            "hpgact": 91002,
            "hpgid": 1114,
            "pgid": "ConvergedTFA",
            "apiCanary": "xxxx",
            "canary": "xxxxxxxxxxxxxxxxxx:1",
            "correlationId": "xxxxxxxxx-xxx-xxxx-xxx-xxxxxxxxx",
            "sessionId": "xxxxxxxxx-xxxx-xxx-xxx-xxxxxxxxx",
            "locale": {
                "mkt": "en-US",
                "lcid": 1033
            },
            "slMaxRetry": 2,
            "slReportFailure": true,
            "strings": {
                "desktopsso": {
                    "authenticatingmessage": "Trying to sign you in"
                }
            },
            "enums": {
                "ClientMetricsModes": {
                    "None": 0,
                    "SubmitOnPost": 1,
                    "SubmitOnRedirect": 2,
                    "InstrumentPlt": 4
                }
            },
            "urls": {
                "instr": {
                    "pageload": "https://login.microsoftonline.com/common/instrumentation/reportpageload",
                    "dssostatus": "https://login.microsoftonline.com/common/instrumentation/dssostatus"
                }
            },
            "browser": {
                "ltr": 1,
                "_Other": 1,
                "Full": 1,
                "RE_Other": 1,
                "b": {
                    "name": "Other",
                    "major": -1,
                    "minor": -1
                },
                "os": {
                    "name": "Unknown",
                    "version": ""
                },
                "V": -1
            },
            "watson": {
                "url": "/common/handlers/watson",
                "bundle": "https://aadcdn.msauth.net/ests/2.1/content/cdnbundles/watson.min_v4uqqpbimbulmncaz2jdxw2.js",
                "sbundle": "https://aadcdn.msauth.net/ests/2.1/content/cdnbundles/watsonsupport.min_3z194vh3l5oibjd0ejgm-q2.js",
                "fbundle": "https://aadcdn.msauth.net/ests/2.1/content/cdnbundles/frameworksupport.min_zhg7it_lri4wqwee0pmhtg2.js",
                "resetErrorPeriod": 5,
                "maxCorsErrors": -1,
                "maxInjectErrors": 5,
                "maxErrors": 10,
                "maxTotalErrors": 3,
                "expSrcs": ["https://login.microsoftonline.com", "https://aadcdn.msauth.net/",
                    "https://aadcdn.msftauth.net/", ".login.microsoftonline.com"
                ],
                "envErrorRedirect": true,
                "envErrorUrl": "/common/handlers/enverror"
            },
            "loader": {
                "cdnRoots": ["https://aadcdn.msauth.net/", "https://aadcdn.msftauth.net/"],
                "logByThrowing": true
            },
            "serverDetails": {
                "slc": "ProdSlices",
                "dc": "SIN2",
                "ri": "ESTXXXX_15",
                "ver": {
                    "v": [2, 1, 10656, 6]
                },
                "rt": "2020-06-02T06:45:58",
                "et": 181
            },
            "country": "JP",
            "fBreakBrandingSigninString": true,
            "fFixIncorrectApiCanaryUsage": true,
            "urlNoCookies": "https://login.microsoftonline.com/cookiesdisabled",
            "fTrimChromeBssoUrl": true,
            "inlineMode": 5
        };
        //]]>
    </script>
    <script type="text/javascript">
        ...(ellipsis contents)
    </script>

    <link rel="prefetch" href="https://login.live.com/Me.htm?v=3" />
    <link rel="shortcut icon" href="https://aadcdn.msauth.net/ests/2.1/content/images/favicon_a_eupayfgghqiai7k9sol6lg2.ico" />

    <script type="text/javascript">
        ServerData = $Config;
    </script>

    <style>
        ... (ellipsis contents)
    </style>

    <script crossorigin="anonymous" src="https://aadcdn.msauth.net/ests/2.1/content/cdnbundles/ux.old.converged.sa.core.min_wihpfkm-4sdas9yapjo2fa2.js"
        onerror='$Loader.On(this,true)' onload='$Loader.On(this)'
        integrity='sha384-zvzK+6sSIL9YSeQ9R4mtb9hS26JyLizNDv+2B/TIS58SzXhlVprF0CVzB+Xvvumd'></script>

    <script type="text/javascript">
        ...(ellipsis contents)
    </script>

    <script type="text/javascript">
        ...(ellipsis contents)
    </script>

    </body>
</html>
```
</details>

Moreover, in the case of MFA, the `loginPasswordResp.URLPost` value is `https://login.microsoftonline.com/common/SAS/ProcessAuth`, which does not match the following conditions.

https://github.com/Versent/saml2aws/blob/8a75db809a21ce7d412b64d3b7e1db593a5d6db6/pkg/provider/aad/aad.go#L857

Therefore, as reported by #464, it becomes an error of `unable to locate IDP oidc form submit URL` at

https://github.com/Versent/saml2aws/blob/8a75db809a21ce7d412b64d3b7e1db593a5d6db6/pkg/provider/aad/aad.go#L905-L907

## Cause

I think that the cause is https://github.com/Versent/saml2aws/pull/435.

It seems that the patch is intend to solve #350.
However, the cause of #350 appears to have already been resolved by #381.
 
---

FIX #464 

8a75db809a21ce7d412b64d3b7e1db593a5d6db6 is the master commit hash at the time this merge request was made.