### PR TITLE
Updated the AWS URN to match actual govCloud URN

### DIFF
--- a/pkg/flags/flags_test.go
+++ b/pkg/flags/flags_test.go
@@ -25,7 +25,7 @@ func TestOverrideAllFlags(t *testing.T) {
 		SkipVerify:           false,
 		URL:                  "https://id.test.com",
 		Username:             "test123",
-		AmazonWebservicesURN: "urn:govcloud:webservices",
+		AmazonWebservicesURN: "urn:amazon:webservices:govcloud",
 	}
 
 	expected := &cfg.IDPAccount{
@@ -59,7 +59,7 @@ func TestNoOverrides(t *testing.T) {
 		SkipVerify:           false,
 		URL:                  "https://id.test.com",
 		Username:             "test123",
-		AmazonWebservicesURN: "urn:govcloud:webservices",
+		AmazonWebservicesURN: "urn:amazon:webservices:govcloud",
 	}
 
 	expected := &cfg.IDPAccount{
@@ -68,7 +68,7 @@ func TestNoOverrides(t *testing.T) {
 		SkipVerify:           false,
 		URL:                  "https://id.test.com",
 		Username:             "test123",
-		AmazonWebservicesURN: "urn:govcloud:webservices",
+		AmazonWebservicesURN: "urn:amazon:webservices:govcloud",
 	}
 	ApplyFlagOverrides(commonFlags, idpa)
 


### PR DESCRIPTION
See the IDP metadata descriptor here for the urn that is provided by AWS GovCloud: https://signin.amazonaws-us-gov.com/static/saml-metadata.xml