### PR TITLE
Support SecurIDv2 Authentication

### DIFF
--- a/pkg/provider/adfs2/rsa.go
+++ b/pkg/provider/adfs2/rsa.go
@@ -115,14 +115,16 @@ func (ac *Client) getLoginForm(loginDetails *creds.LoginDetails) (string, url.Va
 
 	logger.WithField("status", res.StatusCode).WithField("url", loginDetails.URL).WithField("res", dump.ResponseString(res)).Debug("GET")
 
-	// REALLY need to extract the form and actionURL from the previous response
+	// Extract the form and actionURL from the previous response
 
-	authForm := url.Values{}
-	authForm.Add("AuthMethod", "FormsAuthentication")
+	doc, err := goquery.NewDocumentFromResponse(res)
+	authForm, authSubmitURL, err := extractFormData(doc)
 	authForm.Set("UserName", loginDetails.Username)
 	authForm.Set("Password", loginDetails.Password)
 
-	authSubmitURL := fmt.Sprintf("%s/adfs/ls/idpinitiatedsignon", loginDetails.URL)
+	if err != nil {
+		return "", nil, errors.Wrap(err, "error extracting login data")
+	}
 
 	return authSubmitURL, authForm, nil
 }
@@ -200,10 +202,10 @@ func extractFormData(doc *goquery.Document) (url.Values, string, error) {
 			return
 		}
 		val, ok := s.Attr("value")
-		if !ok {
+		if !ok || len(val) == 0 {
 			return
 		}
-		formData.Add(name, val)
+		formData.Set(name, val)
 	})
 
 	return formData, actionURL, nil

--- a/pkg/provider/adfs2/rsa_test.go
+++ b/pkg/provider/adfs2/rsa_test.go
@@ -38,6 +38,7 @@ func TestClient_getLoginForm(t *testing.T) {
 		"UserName":   []string{"test"},
 		"Password":   []string{"test123"},
 		"AuthMethod": []string{"FormsAuthentication"},
+		"Kmsi":       []string{"true"},
 	}, authForm)
 }
 


### PR DESCRIPTION
Fixes #340, adding support for SecurIDv2Authentication and improving form data extraction.

An additional POST call is needed to establish a context:
- https://github.com/torric1/AWSCLI-MFA-RSAv2/blob/master/ros_aws-cli-py3-adfs3-mfa-securID.txt#L128-L132
- https://gist.github.com/jgard/17262e0fc073c82bc7930db2f5603446#file-get-awstempcred-ps1-L25-L29

