### PR TITLE
Add support for using DUO Trusted Device certificate validation

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/Azure/go-ntlmssp v0.0.0-20180416175057-4b934ac9dad3 h1:r8SecdrDTMoF5D
 github.com/Azure/go-ntlmssp v0.0.0-20180416175057-4b934ac9dad3/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8 h1:xzYJEypr/85nBpB11F9br+3HUrpgb+fcm5iADzXXYEw=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
-github.com/PuerkitoBio/goquery v1.4.1 h1:smcIRGdYm/w7JSbcdeLHEMzxmsBQvl8lhf0dSw2nzMI=
-github.com/PuerkitoBio/goquery v1.4.1/go.mod h1:T9ezsOHcCrDCgA8aF1Cqr3sSYbO/xgdy8/R/XiIMAhA=
 github.com/PuerkitoBio/goquery v1.5.1 h1:PSPBGne8NIUWw+/7vFBV+kG2J/5MOjbzc7154OaKCSE=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/alecthomas/kingpin v2.2.6+incompatible h1:5svnBTFgJjZvGKyYBtMB0+m5wvrbUHiqye8wRJMlnYI=
@@ -16,8 +14,6 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5Vpd
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20190910110746-680d30ca3117 h1:aUo+WrWZtRRfc6WITdEKzEczFRlEpfW15NhNeLRc17U=
 github.com/alecthomas/units v0.0.0-20190910110746-680d30ca3117/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/andybalholm/cascadia v1.0.0 h1:hOCXnnZ5A+3eVDX8pvgl4kofXv2ELss0bKcqRySc45o=
-github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/andybalholm/cascadia v1.1.0 h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5zzsLTo=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/aulanov/go.dbus v0.0.0-20150729231527-25c3068a42a0 h1:EEDvbomAQ+MFWqJ9FM6RXyJTkc4lckyWsbc5CGQkG1Y=

--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -480,8 +480,6 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 
 		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-		//submitReq := req
-
 		res, err = oc.client.Do(req)
 		if err != nil {
 			return "", errors.Wrap(err, "error retrieving verify response")

--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -527,6 +527,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 				return "", errors.Wrap(err, "error building cert validation request")
 			}
 
+			req.Header.Add("Referer", "https://" + duoHost)
 			res, err = oc.client.Do(req)
 			oc.client.Transport = originalTransport
 
@@ -535,10 +536,12 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 				duoCertURL := fmt.Sprintf("%s?sid=%s&certs_txid=%s&type=AJAX", certUrl, url.QueryEscape(sid), txid)
 
 				req, err = http.NewRequest("GET", duoCertURL, nil)
+
 				if err != nil {
 					return "", errors.Wrap(err, "error building cert validation request ")
 				}
 
+				req.Header.Add("Referer", "https://" + duoHost)
 				res, err = oc.client.Do(req)
 
 				if err != nil {

--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -583,11 +583,11 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 			}
 			defer res.Body.Close()
 
-		}
+			doc, err = goquery.NewDocumentFromResponse(res)
+			if err != nil {
+				return "", errors.Wrap(err, "error parsing document")
+			}
 
-		doc, err = goquery.NewDocumentFromResponse(res)
-		if err != nil {
-			return "", errors.Wrap(err, "error parsing document")
 		}
 
 		duoSID, ok := doc.Find("input[name=\"sid\"]").Attr("value")


### PR DESCRIPTION
Duo has a feature that allows you to validate the endpoint being used is trusted when doing push notifications.  If this is enabled, it adds a certificate check requirement on your device to validate against a known certificate that was pushed to your device's cert store.

This PR adds flow such that if the web response includes this validation, we perform it as some additional steps (which is required, or the push notification will not occur).

This should be no change to the existing flow for those without this feature enabled.