### PR TITLE
Keycloak follow redirect on 401 response

### DIFF
--- a/pkg/provider/keycloak/example/redirect.html
+++ b/pkg/provider/keycloak/example/redirect.html
@@ -1,0 +1,16 @@
+<HTML>
+
+<HEAD>
+	<TITLE>Kerberos Unsupported</TITLE>
+</HEAD>
+
+<BODY Onload="document.forms[0].submit()">
+	<FORM METHOD="POST" ACTION="https://id.example.com/auth/realms/master/login-actions/authenticate?code=G5PSj-AJ7mC2wRS5yOA5NEGZ7BO97Y0_qUkS5zInmhQ&execution=e0c4f6fe-6f9a-435e-a7ff-d61eb2456d58&client_id=urn%3Aamazon%3Awebservices">
+		<NOSCRIPT>
+			<P>JavaScript is disabled. We strongly recommend to enable it. You were unable to login via Kerberos.  Click the button below to login via an alternative method .</P>
+			<INPUT name="continue" TYPE="SUBMIT" VALUE="CONTINUE" />
+		</NOSCRIPT>
+	</FORM>
+</BODY>
+
+</HTML>

--- a/pkg/provider/keycloak/keycloak.go
+++ b/pkg/provider/keycloak/keycloak.go
@@ -101,6 +101,15 @@ func (kc *Client) getLoginForm(loginDetails *creds.LoginDetails) (string, url.Va
 		return "", nil, errors.Wrap(err, "failed to build document from response")
 	}
 
+	if res.StatusCode == http.StatusUnauthorized {
+		authSubmitURL, err := extractSubmitURL(doc)
+		if err != nil {
+			return "", nil, errors.Wrap(err, "unable to locate IDP authentication form submit URL")
+		}
+		loginDetails.URL = authSubmitURL
+		return kc.getLoginForm(loginDetails)
+	}
+
 	authForm := url.Values{}
 
 	doc.Find("input").Each(func(i int, s *goquery.Selection) {

--- a/pkg/provider/keycloak/keycloak_test.go
+++ b/pkg/provider/keycloak/keycloak_test.go
@@ -59,7 +59,7 @@ func TestClient_getLoginFormRedirect(t *testing.T) {
 			w.Write(data)
 		} else {
 			w.WriteHeader(http.StatusUnauthorized)
-			w.Write(bytes.Replace(redirectData, []byte(exampleLoginURL), []byte("http://" + r.Host), 1))
+			w.Write(bytes.Replace(redirectData, []byte(exampleLoginURL), []byte("http://"+r.Host), 1))
 		}
 		count += 1
 	}))


### PR DESCRIPTION
This enables the Keycloak provider to login when the SAML login page
responds with an `401 Unauthorized` response.

Closes #541 