### PR TITLE
Add an option to specify the expected sign-in destination

### DIFF
--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -30,22 +30,23 @@ const (
 
 // IDPAccount saml IDP account
 type IDPAccount struct {
-	AppID                string `ini:"app_id"` // used by OneLogin and AzureAD
-	URL                  string `ini:"url"`
-	Username             string `ini:"username"`
-	Provider             string `ini:"provider"`
-	MFA                  string `ini:"mfa"`
-	SkipVerify           bool   `ini:"skip_verify"`
-	Timeout              int    `ini:"timeout"`
-	AmazonWebservicesURN string `ini:"aws_urn"`
-	SessionDuration      int    `ini:"aws_session_duration"`
-	Profile              string `ini:"aws_profile"`
-	ResourceID           string `ini:"resource_id"` // used by F5APM
-	Subdomain            string `ini:"subdomain"`   // used by OneLogin
-	RoleARN              string `ini:"role_arn"`
-	Region               string `ini:"region"`
-	HttpAttemptsCount    string `ini:"http_attempts_count"`
-	HttpRetryDelay       string `ini:"http_retry_delay"`
+	AppID                string   `ini:"app_id"` // used by OneLogin and AzureAD
+	URL                  string   `ini:"url"`
+	Username             string   `ini:"username"`
+	Provider             string   `ini:"provider"`
+	MFA                  string   `ini:"mfa"`
+	SkipVerify           bool     `ini:"skip_verify"`
+	Timeout              int      `ini:"timeout"`
+	AmazonWebservicesURN string   `ini:"aws_urn"`
+	SessionDuration      int      `ini:"aws_session_duration"`
+	Profile              string   `ini:"aws_profile"`
+	ResourceID           string   `ini:"resource_id"` // used by F5APM
+	Subdomain            string   `ini:"subdomain"`   // used by OneLogin
+	RoleARN              string   `ini:"role_arn"`
+	Region               string   `ini:"region"`
+	HttpAttemptsCount    string   `ini:"http_attempts_count"`
+	HttpRetryDelay       string   `ini:"http_retry_delay"`
+	SigninURLS           []string `ini:"aws_signin_urls"`
 }
 
 func (ia IDPAccount) String() string {

--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -98,7 +98,7 @@ func New(idpAccount *cfg.IDPAccount) (*Client, error) {
 
 	return &Client{
 		client:       client,
-		mfa:          idpAccount.MFA,
+		mfa:          strings.ToUpper(idpAccount.MFA),
 		destinations: destinations,
 	}, nil
 }
@@ -308,7 +308,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 		}
 	}
 
-	if strings.ToUpper(oc.mfa) != "AUTO" {
+	if oc.mfa != "AUTO" {
 		for idx, val := range mfaOptions {
 			if strings.HasPrefix(strings.ToUpper(val), oc.mfa) {
 				mfaOption = idx


### PR DESCRIPTION
The support multiple redirects and intermediate SAML relays has required to know the final AWS sign-in URL and detect it in the redirection loops. This means all the relays addresses needs to be known in advance, and support for new ones cannot be supported at all.

This change allows, while keeping a sane default value referencing all known AWS saml relays, to support any other one in case some users faces specific cases, or even, wants to use the code to authenticate to any other service provider.