### PR TITLE
Docs Update - Keep the CLI installation steps consistent

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ If you're on OSX you can install saml2aws using homebrew!
 ```
 brew tap versent/homebrew-taps
 brew install saml2aws
+saml2aws --version
 ```
 
 ### Windows
@@ -88,6 +89,7 @@ $ CURRENT_VERSION=2.26.1
 $ wget https://github.com/Versent/saml2aws/releases/download/v${CURRENT_VERSION}/saml2aws_${CURRENT_VERSION}_linux_amd64.tar.gz
 $ tar -xzvf saml2aws_${CURRENT_VERSION}_linux_amd64.tar.gz -C ~/.local/bin
 $ chmod u+x ~/.local/bin/saml2aws
+$ saml2aws --version
 ```
 **Note**: You will need to logout of your current user session or force a bash reload for `saml2aws` to be useable after following the above steps.
 


### PR DESCRIPTION
I noticed that the instructions for Windows runs the `saml2aws --version` to verify its installation. But this command was missing in the MacOS and Linux equivalent.

This is a simple update to the README 

- keeps the instruction consistent across OSes.
- it is a helpful CLI command to verify the installation steps ran correctly.