### PR TITLE
Updating broken URL for IDP Issues

### DIFF
--- a/cmd/saml2aws/commands/list_roles.go
+++ b/cmd/saml2aws/commands/list_roles.go
@@ -49,7 +49,7 @@ func ListRoles(loginFlags *flags.LoginExecFlags) error {
 	if samlAssertion == "" {
 		log.Println("Response did not contain a valid SAML assertion")
 		log.Println("Please check your username and password is correct")
-		log.Println("To see the output follow the instructions in https://github.com/versent/saml2aws/v2#debugging-issues-with-idps")
+		log.Println("To see the output follow the instructions in https://github.com/versent/saml2aws#debugging-issues-with-idps")
 		os.Exit(1)
 	}
 

--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -76,7 +76,7 @@ func Login(loginFlags *flags.LoginExecFlags) error {
 	if samlAssertion == "" {
 		log.Println("Response did not contain a valid SAML assertion")
 		log.Println("Please check your username and password is correct")
-		log.Println("To see the output follow the instructions in https://github.com/versent/saml2aws/v2#debugging-issues-with-idps")
+		log.Println("To see the output follow the instructions in https://github.com/versent/saml2aws#debugging-issues-with-idps")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
related to:
resolves: #551

## Background

When errors occur with Authentication, the message below is displayed:
```
Response did not contain a valid SAML assertion
Please check your username and password is correct
To see the output follow the instructions in https://github.com/versent/saml2aws/v2#debugging-issues-with-idps
```

This URL, resulted in a 404 which should now be fixed

## Changes

* `https://github.com/versent/saml2aws/v2#debugging-issues-with-idps` -> `https://github.com/versent/saml2aws#debugging-issues-with-idps`

## Testing

Built the binary locally and the link now works :D 