### PR TITLE
Add flag to fetch credentials for all roles for a given profile

### DIFF
--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -99,6 +99,7 @@ func main() {
 	cmdLogin.Flag("client-id", "OneLogin client id, used to generate API access token. (env: ONELOGIN_CLIENT_ID)").Envar("ONELOGIN_CLIENT_ID").StringVar(&commonFlags.ClientID)
 	cmdLogin.Flag("client-secret", "OneLogin client secret, used to generate API access token. (env: ONELOGIN_CLIENT_SECRET)").Envar("ONELOGIN_CLIENT_SECRET").StringVar(&commonFlags.ClientSecret)
 	cmdLogin.Flag("force", "Refresh credentials even if not expired.").BoolVar(&loginFlags.Force)
+	cmdLogin.Flag("all", "Fetch all credentials for a user").BoolVar(&loginFlags.All)
 
 	// `exec` command and settings
 	cmdExec := app.Command("exec", "Exec the supplied command with env vars from STS token.")

--- a/input.go
+++ b/input.go
@@ -109,3 +109,17 @@ func PromptForAWSRoleSelection(accounts []*AWSAccount) (*AWSRole, error) {
 
 	return roles[selectedRole], nil
 }
+
+// AllRoles returns an array of all eligible aws roles
+func AllRoles(accounts []*AWSAccount) []*AWSRole {
+
+	roles := []*AWSRole{}
+
+	for _, account := range accounts {
+		for _, role := range account.Roles {
+			roles = append(roles, role)
+		}
+	}
+
+	return roles
+}

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -33,6 +33,7 @@ type CommonFlags struct {
 type LoginExecFlags struct {
 	CommonFlags  *CommonFlags
 	Force        bool
+	All          bool
 	DuoMFAOption string
 	ExecProfile  string
 }


### PR DESCRIPTION
I intend to fetch **credentials** for all available roles for a given profile. In this PR, this is accomplished by adding a new option `--all`. So when  the user runs `saml2aws login --all`, the role selection prompt is bypassed and credentials for every available role are fetched and added to the credentials file. The profile names in the credential file in this case are autogenerated as saml1, saml2 etc. I think this is something that can be improved upon. However, please let me know if this is an acceptable approach.