### PR TITLE
Support multiple fido devices in Okta

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -6,8 +6,6 @@ github.com/Azure/go-ntlmssp v0.0.0-20180416175057-4b934ac9dad3 h1:r8SecdrDTMoF5D
 github.com/Azure/go-ntlmssp v0.0.0-20180416175057-4b934ac9dad3/go.mod h1:chxPXzSsl7ZWRAuOIE23GDNzjWuZquvFlgA8xmpunjU=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8 h1:xzYJEypr/85nBpB11F9br+3HUrpgb+fcm5iADzXXYEw=
 github.com/Netflix/go-expect v0.0.0-20180615182759-c93bf25de8e8/go.mod h1:oX5x61PbNXchhh0oikYAH+4Pcfw5LKv21+Jnpr6r6Pc=
-github.com/PuerkitoBio/goquery v1.4.1 h1:smcIRGdYm/w7JSbcdeLHEMzxmsBQvl8lhf0dSw2nzMI=
-github.com/PuerkitoBio/goquery v1.4.1/go.mod h1:T9ezsOHcCrDCgA8aF1Cqr3sSYbO/xgdy8/R/XiIMAhA=
 github.com/PuerkitoBio/goquery v1.5.1 h1:PSPBGne8NIUWw+/7vFBV+kG2J/5MOjbzc7154OaKCSE=
 github.com/PuerkitoBio/goquery v1.5.1/go.mod h1:GsLWisAFVj4WgDibEWF4pvYnkVQBpKBKeU+7zCJoLcc=
 github.com/alecthomas/kingpin v2.2.6+incompatible h1:5svnBTFgJjZvGKyYBtMB0+m5wvrbUHiqye8wRJMlnYI=
@@ -16,8 +14,6 @@ github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5Vpd
 github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
 github.com/alecthomas/units v0.0.0-20190910110746-680d30ca3117 h1:aUo+WrWZtRRfc6WITdEKzEczFRlEpfW15NhNeLRc17U=
 github.com/alecthomas/units v0.0.0-20190910110746-680d30ca3117/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
-github.com/andybalholm/cascadia v1.0.0 h1:hOCXnnZ5A+3eVDX8pvgl4kofXv2ELss0bKcqRySc45o=
-github.com/andybalholm/cascadia v1.0.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/andybalholm/cascadia v1.1.0 h1:BuuO6sSfQNFRu1LppgbD25Hr2vLYW25JvxHs5zzsLTo=
 github.com/andybalholm/cascadia v1.1.0/go.mod h1:GsXiBklL0woXo1j/WYWtSYYC4ouU9PqHO0sqidkEA4Y=
 github.com/aulanov/go.dbus v0.0.0-20150729231527-25c3068a42a0 h1:EEDvbomAQ+MFWqJ9FM6RXyJTkc4lckyWsbc5CGQkG1Y=

--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -16,6 +16,7 @@ import (
 	"time"
 
 	"github.com/PuerkitoBio/goquery"
+	"github.com/marshallbrekka/go-u2fhost"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/tidwall/gjson"
@@ -69,6 +70,14 @@ type AuthRequest struct {
 type VerifyRequest struct {
 	StateToken string `json:"stateToken"`
 	PassCode   string `json:"passCode,omitempty"`
+}
+
+// mfaChallengeContext is used to hold MFA challenge context in a simple struct.
+type mfaChallengeContext struct {
+	factorID              string
+	oktaVerify            string
+	mfaIdentifer          string
+	challengeResponseBody string
 }
 
 // New creates a new Okta client
@@ -285,33 +294,20 @@ func extractSAMLResponse(doc *goquery.Document) (v string, ok bool) {
 	return doc.Find("input[name=\"SAMLResponse\"]").Attr("value")
 }
 
-func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails, resp string) (string, error) {
+func findMfaOption(mfa string, mfaOptions []string, startAtIdx int) int {
+	for idx, val := range mfaOptions {
+		if startAtIdx >= idx {
+			continue
+		}
+		if strings.HasPrefix(strings.ToUpper(val), mfa) {
+			return idx
+		}
+	}
+	return 0
+}
 
+func getMfaChallengeContext(oc *Client, mfaOption int, resp string) (*mfaChallengeContext, error) {
 	stateToken := gjson.Get(resp, "stateToken").String()
-
-	// choose an mfa option if there are multiple enabled
-	mfaOption := 0
-	var mfaOptions []string
-	for i := range gjson.Get(resp, "_embedded.factors").Array() {
-		identifier := parseMfaIdentifer(resp, i)
-		if val, ok := supportedMfaOptions[identifier]; ok {
-			mfaOptions = append(mfaOptions, val)
-		} else {
-			mfaOptions = append(mfaOptions, "UNSUPPORTED: "+identifier)
-		}
-	}
-
-	if strings.ToUpper(oc.mfa) != "AUTO" {
-		for idx, val := range mfaOptions {
-			if strings.HasPrefix(strings.ToUpper(val), oc.mfa) {
-				mfaOption = idx
-				break
-			}
-		}
-	} else if len(mfaOptions) > 1 {
-		mfaOption = prompter.Choose("Select which MFA option to use", mfaOptions)
-	}
-
 	factorID := gjson.Get(resp, fmt.Sprintf("_embedded.factors.%d.id", mfaOption)).String()
 	oktaVerify := gjson.Get(resp, fmt.Sprintf("_embedded.factors.%d._links.verify.href", mfaOption)).String()
 	mfaIdentifer := parseMfaIdentifer(resp, mfaOption)
@@ -319,7 +315,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 	logger.WithField("factorID", factorID).WithField("oktaVerify", oktaVerify).WithField("mfaIdentifer", mfaIdentifer).Debug("MFA")
 
 	if _, ok := supportedMfaOptions[mfaIdentifer]; !ok {
-		return "", errors.New("unsupported mfa provider")
+		return nil, errors.New("unsupported mfa provider")
 	}
 
 	// get signature & callback
@@ -338,12 +334,12 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 
 	err := json.NewEncoder(verifyBody).Encode(verifyReq)
 	if err != nil {
-		return "", errors.Wrap(err, "error encoding verifyReq")
+		return nil, errors.Wrap(err, "error encoding verifyReq")
 	}
 
 	req, err := http.NewRequest("POST", oktaVerify, verifyBody)
 	if err != nil {
-		return "", errors.Wrap(err, "error building verify request")
+		return nil, errors.Wrap(err, "error building verify request")
 	}
 
 	req.Header.Add("Content-Type", "application/json")
@@ -351,18 +347,51 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 
 	res, err := oc.client.Do(req)
 	if err != nil {
-		return "", errors.Wrap(err, "error retrieving verify response")
+		return nil, errors.Wrap(err, "error retrieving verify response")
 	}
 
 	body, err := ioutil.ReadAll(res.Body)
 	if err != nil {
-		return "", errors.Wrap(err, "error retrieving body from response")
+		return nil, errors.Wrap(err, "error retrieving body from response")
 	}
-	resp = string(body)
 
-	switch mfa := mfaIdentifer; mfa {
+	return &mfaChallengeContext{
+		factorID:              factorID,
+		oktaVerify:            oktaVerify,
+		mfaIdentifer:          mfaIdentifer,
+		challengeResponseBody: string(body),
+	}, nil
+}
+
+func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails, resp string) (string, error) {
+	stateToken := gjson.Get(resp, "stateToken").String()
+
+	// choose an mfa option if there are multiple enabled
+	mfaOption := 0
+	var mfaOptions []string
+	for i := range gjson.Get(resp, "_embedded.factors").Array() {
+		identifier := parseMfaIdentifer(resp, i)
+		if val, ok := supportedMfaOptions[identifier]; ok {
+			mfaOptions = append(mfaOptions, val)
+		} else {
+			mfaOptions = append(mfaOptions, "UNSUPPORTED: "+identifier)
+		}
+	}
+
+	if strings.ToUpper(oc.mfa) != "AUTO" {
+		mfaOption = findMfaOption(oc.mfa, mfaOptions, 0)
+	} else if len(mfaOptions) > 1 {
+		mfaOption = prompter.Choose("Select which MFA option to use", mfaOptions)
+	}
+
+	challengeContext, err := getMfaChallengeContext(oc, mfaOption, resp)
+	if err != nil {
+		return "", err
+	}
+
+	switch mfa := challengeContext.mfaIdentifer; mfa {
 	case IdentifierYubiMfa:
-		return gjson.Get(resp, "sessionToken").String(), nil
+		return gjson.Get(challengeContext.challengeResponseBody, "sessionToken").String(), nil
 	case IdentifierSmsMfa, IdentifierTotpMfa, IdentifierOktaTotpMfa, IdentifierSymantecTotpMfa:
 		var verifyCode = loginDetails.MFAToken
 		if verifyCode == "" {
@@ -375,7 +404,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 			return "", errors.Wrap(err, "error encoding token data")
 		}
 
-		req, err = http.NewRequest("POST", oktaVerify, tokenBody)
+		req, err := http.NewRequest("POST", challengeContext.oktaVerify, tokenBody)
 		if err != nil {
 			return "", errors.Wrap(err, "error building token post request")
 		}
@@ -402,31 +431,26 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 		fmt.Printf("\nWaiting for approval, please check your Okta Verify app ...")
 
 		// loop until success, error, or timeout
+		body := challengeContext.challengeResponseBody
 		for {
-
-			res, err = oc.client.Do(req)
-			if err != nil {
-				return "", errors.Wrap(err, "error retrieving verify response")
-			}
-
-			body, err = ioutil.ReadAll(res.Body)
-			if err != nil {
-				return "", errors.Wrap(err, "error retrieving body from response")
-			}
-
 			// on 'success' status
-			if gjson.Get(string(body), "status").String() == "SUCCESS" {
+			if gjson.Get(body, "status").String() == "SUCCESS" {
 				fmt.Printf(" Approved\n\n")
-				return gjson.Get(string(body), "sessionToken").String(), nil
+				return gjson.Get(body, "sessionToken").String(), nil
 			}
 
 			// otherwise probably still waiting
-			switch gjson.Get(string(body), "factorResult").String() {
+			switch gjson.Get(body, "factorResult").String() {
 
 			case "WAITING":
 				time.Sleep(3 * time.Second)
 				fmt.Printf(".")
 				logger.Debug("Waiting for user to authorize login")
+				updatedContext, err := getMfaChallengeContext(oc, mfaOption, resp)
+				if err != nil {
+					return "", err
+				}
+				body = updatedContext.challengeResponseBody
 
 			case "TIMEOUT":
 				fmt.Printf(" Timeout\n")
@@ -445,12 +469,12 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 		}
 
 	case IdentifierDuoMfa:
-		duoHost := gjson.Get(resp, "_embedded.factor._embedded.verification.host").String()
-		duoSignature := gjson.Get(resp, "_embedded.factor._embedded.verification.signature").String()
+		duoHost := gjson.Get(challengeContext.challengeResponseBody, "_embedded.factor._embedded.verification.host").String()
+		duoSignature := gjson.Get(challengeContext.challengeResponseBody, "_embedded.factor._embedded.verification.signature").String()
 		duoSiguatres := strings.Split(duoSignature, ":")
 		//duoSignatures[0] = TX
 		//duoSignatures[1] = APP
-		duoCallback := gjson.Get(resp, "_embedded.factor._embedded.verification._links.complete.href").String()
+		duoCallback := gjson.Get(challengeContext.challengeResponseBody, "_embedded.factor._embedded.verification._links.complete.href").String()
 
 		// initiate duo mfa to get sid
 		duoSubmitURL := fmt.Sprintf("https://%s/frame/web/v1/auth", duoHost)
@@ -464,7 +488,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 		duoForm.Add("screen_resolution_height", "1692")
 		duoForm.Add("color_depth", "24")
 
-		req, err = http.NewRequest("POST", duoSubmitURL, strings.NewReader(duoForm.Encode()))
+		req, err := http.NewRequest("POST", duoSubmitURL, strings.NewReader(duoForm.Encode()))
 		if err != nil {
 			return "", errors.Wrap(err, "error building authentication request")
 		}
@@ -474,7 +498,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 
 		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 
-		res, err = oc.client.Do(req)
+		res, err := oc.client.Do(req)
 		if err != nil {
 			return "", errors.Wrap(err, "error retrieving verify response")
 		}
@@ -539,7 +563,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 			return "", errors.Wrap(err, "error retrieving verify response")
 		}
 
-		body, err = ioutil.ReadAll(res.Body)
+		body, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			return "", errors.Wrap(err, "error retrieving body from response")
 		}
@@ -667,7 +691,7 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 
 		// callback to okta with cookie
 		oktaForm := url.Values{}
-		oktaForm.Add("id", factorID)
+		oktaForm.Add("id", challengeContext.factorID)
 		oktaForm.Add("stateToken", stateToken)
 		oktaForm.Add("sig_response", fmt.Sprintf("%s:%s", duoTxCookie, duoSiguatres[1]))
 
@@ -685,14 +709,14 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 
 		// extract okta session token
 
-		verifyReq = VerifyRequest{StateToken: stateToken}
-		verifyBody = new(bytes.Buffer)
+		verifyReq := VerifyRequest{StateToken: stateToken}
+		verifyBody := new(bytes.Buffer)
 		err = json.NewEncoder(verifyBody).Encode(verifyReq)
 		if err != nil {
 			return "", errors.Wrap(err, "error encoding verify request")
 		}
 
-		req, err = http.NewRequest("POST", oktaVerify, verifyBody)
+		req, err = http.NewRequest("POST", challengeContext.oktaVerify, verifyBody)
 		if err != nil {
 			return "", errors.Wrap(err, "error building verify request")
 		}
@@ -714,42 +738,70 @@ func verifyMfa(oc *Client, oktaOrgHost string, loginDetails *creds.LoginDetails,
 		return gjson.GetBytes(body, "sessionToken").String(), nil
 
 	case IdentifierFIDOWebAuthn:
-		nonce := gjson.Get(resp, "_embedded.factor._embedded.challenge.challenge").String()
-		credentialID := gjson.Get(resp, "_embedded.factor.profile.credentialId").String()
-		version := gjson.Get(resp, "_embedded.factor.profile.version").String()
-		appID := oktaOrgHost
-		webauthnCallback := gjson.Get(resp, "_links.next.href").String()
+		var authErr error
+		var signedAssertion *SignedAssertion
+		challengeResponseBody := challengeContext.challengeResponseBody
+		lastMfaOption := mfaOption
 
-		fidoClient, err := NewFidoClient(nonce,
-			appID,
-			version,
-			credentialID,
-			stateToken,
-			new(U2FDeviceFinder))
-		if err != nil {
-			return "", err
-		}
+		for {
+			nonce := gjson.Get(challengeResponseBody, "_embedded.factor._embedded.challenge.challenge").String()
+			credentialID := gjson.Get(challengeResponseBody, "_embedded.factor.profile.credentialId").String()
+			version := gjson.Get(challengeResponseBody, "_embedded.factor.profile.version").String()
 
-		signedAssertion, err := fidoClient.ChallengeU2F()
-		if err != nil {
-			return "", err
+			fidoClient, err := NewFidoClient(
+				nonce,
+				oktaOrgHost,
+				version,
+				credentialID,
+				stateToken,
+				new(U2FDeviceFinder),
+			)
+
+			if err != nil {
+				return "", err
+			}
+
+			signedAssertion, authErr = fidoClient.ChallengeU2F()
+
+			if _, ok := authErr.(*u2fhost.BadKeyHandleError); ok {
+				nextMfaOption := findMfaOption(oc.mfa, mfaOptions, lastMfaOption)
+				if nextMfaOption <= lastMfaOption {
+					return "", authErr
+				}
+				lastMfaOption = nextMfaOption
+
+				nextChallengeContext, err := getMfaChallengeContext(oc, nextMfaOption, resp)
+				if err != nil {
+					return "", err
+				}
+				challengeResponseBody = nextChallengeContext.challengeResponseBody
+				continue
+			}
+
+			if err != nil {
+				return "", err
+			}
+
+			break
 		}
 
 		payload, err := json.Marshal(signedAssertion)
 		if err != nil {
 			return "", err
 		}
-		req, err = http.NewRequest("POST", webauthnCallback, strings.NewReader(string(payload)))
+
+		webauthnCallback := gjson.Get(challengeResponseBody, "_links.next.href").String()
+		req, err := http.NewRequest("POST", webauthnCallback, strings.NewReader(string(payload)))
 		if err != nil {
 			return "", errors.Wrap(err, "error building authentication request")
 		}
 		req.Header.Add("Accept", "application/json")
 		req.Header.Add("Content-Type", "application/json")
-		res, err = oc.client.Do(req)
+		res, err := oc.client.Do(req)
 		if err != nil {
 			return "", errors.Wrap(err, "error retrieving verify response")
 		}
-		body, err = ioutil.ReadAll(res.Body)
+		body, err := ioutil.ReadAll(res.Body)
 		if err != nil {
 			return "", errors.Wrap(err, "error retrieving body from response")
 		}


### PR DESCRIPTION
## Overview

Okta allows you to attach multiple Fido devices to your account, but `saml2aws` will only attempt the use the first device in the list returned from Okta. This results in an authentication failure if the local device does not match, with no way to select another device. This PR iterates through each Fido device on the account looking for a match on the local system. 

This required a slight refactor to make requests to Okta's verification endpoints more reusable, but will make future refactoring easier.