### PR TITLE
Fix keycloak login when SAML response page contains input fields without 'name' attribute

### DIFF
--- a/pkg/provider/keycloak/example/assertion.html
+++ b/pkg/provider/keycloak/example/assertion.html
@@ -7,6 +7,7 @@
 
 <BODY Onload="document.forms[0].submit()">
     <FORM METHOD="POST" ACTION="https://signin.aws.amazon.com/saml">
+        <INPUT TYPE="BUTTON" VALUE="Click"/>
         <INPUT TYPE="HIDDEN" NAME="SAMLResponse" VALUE="abc123"
         />
         <NOSCRIPT>

--- a/pkg/provider/keycloak/keycloak.go
+++ b/pkg/provider/keycloak/keycloak.go
@@ -186,10 +186,7 @@ func extractSamlResponse(doc *goquery.Document) string {
 
 	doc.Find("input").Each(func(i int, s *goquery.Selection) {
 		name, ok := s.Attr("name")
-		if !ok {
-			log.Fatalf("unable to locate IDP authentication form submit URL")
-		}
-		if name == "SAMLResponse" {
+		if ( ok && name == "SAMLResponse" ) {
 			val, ok := s.Attr("value")
 			if !ok {
 				log.Fatalf("unable to locate saml assertion value")
@@ -197,6 +194,10 @@ func extractSamlResponse(doc *goquery.Document) string {
 			samlAssertion = val
 		}
 	})
+
+	if samlAssertion == "" {
+		log.Fatalf("unable to locate saml response field")
+	}
 
 	return samlAssertion
 }

--- a/pkg/provider/keycloak/keycloak.go
+++ b/pkg/provider/keycloak/keycloak.go
@@ -70,23 +70,7 @@ func (kc *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 		}
 	}
 
-	var samlAssertion string
-
-	doc.Find("input").Each(func(i int, s *goquery.Selection) {
-		name, ok := s.Attr("name")
-		if !ok {
-			log.Fatalf("unable to locate IDP authentication form submit URL")
-		}
-		if name == "SAMLResponse" {
-			val, ok := s.Attr("value")
-			if !ok {
-				log.Fatalf("unable to locate saml assertion value")
-			}
-			samlAssertion = val
-		}
-	})
-
-	return samlAssertion, nil
+	return extractSamlResponse(doc), nil
 }
 
 func (kc *Client) getLoginForm(loginDetails *creds.LoginDetails) (string, url.Values, error) {
@@ -195,6 +179,26 @@ func extractSubmitURL(doc *goquery.Document) (string, error) {
 	}
 
 	return submitURL, nil
+}
+
+func extractSamlResponse(doc *goquery.Document) string {
+	var samlAssertion string
+
+	doc.Find("input").Each(func(i int, s *goquery.Selection) {
+		name, ok := s.Attr("name")
+		if !ok {
+			log.Fatalf("unable to locate IDP authentication form submit URL")
+		}
+		if name == "SAMLResponse" {
+			val, ok := s.Attr("value")
+			if !ok {
+				log.Fatalf("unable to locate saml assertion value")
+			}
+			samlAssertion = val
+		}
+	})
+
+	return samlAssertion
 }
 
 func containsTotpForm(doc *goquery.Document) bool {

--- a/pkg/provider/keycloak/keycloak_test.go
+++ b/pkg/provider/keycloak/keycloak_test.go
@@ -156,6 +156,16 @@ func TestClient_postTotpFormWithProvidedMFAToken(t *testing.T) {
 	pr.Mock.AssertNumberOfCalls(t, "RequestSecurityCode", 0)
 }
 
+func TestClient_extractSamlResponse(t *testing.T) {
+	data, err := ioutil.ReadFile("example/assertion.html")
+	require.Nil(t, err)
+
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(data))
+	require.Nil(t, err)
+
+	require.Equal(t, extractSamlResponse(doc), "abc123")
+}
+
 func TestClient_containsTotpForm(t *testing.T) {
 	data, err := ioutil.ReadFile("example/mfapage.html")
 	require.Nil(t, err)


### PR DESCRIPTION
This fixes https://github.com/Versent/saml2aws/issues/566