### PR TITLE
modify page processor to work with action-less forms

### DIFF
--- a/pkg/page/form.go
+++ b/pkg/page/form.go
@@ -52,10 +52,11 @@ func NewFormFromDocument(doc *goquery.Document, formFilter string) (*Form, error
 	}
 
 	attrValue, ok := formSelection.Attr("action")
-	if !ok {
-		return nil, fmt.Errorf("could not extract form action")
+	if ok {
+		form.URL = attrValue
+	} else {
+		form.URL = doc.Url.String()
 	}
-	form.URL = attrValue
 
 	attrValue, ok = formSelection.Attr("method")
 	if ok {


### PR DESCRIPTION
if a form doesn't have an "action" attribute, the processor
falls back to using the page's document.URL instead of failing