### PR TITLE
send "credentials are not expired" to debug log

### DIFF
--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -45,7 +45,7 @@ func Login(loginFlags *flags.LoginExecFlags) error {
 	}
 
 	if !sharedCreds.Expired() && !loginFlags.Force {
-		log.Println("credentials are not expired skipping")
+		logger.Debug("credentials are not expired skipping")
 		previous_creds, err := sharedCreds.Load()
 		if err != nil {
 			log.Println("Unable to load cached credentials")


### PR DESCRIPTION
makes the login process less verbose by default when credentials are current, but still keeps the message available if someone really wants it