### PR TITLE
add support for `USER` and `PASSWORD` fields in pingfed provider

### DIFF
--- a/pkg/provider/pingfed/pingfed.go
+++ b/pkg/provider/pingfed/pingfed.go
@@ -136,6 +136,8 @@ func (ac *Client) handleLogin(ctx context.Context, doc *goquery.Document) (conte
 
 	form.Values.Set("pf.username", loginDetails.Username)
 	form.Values.Set("pf.pass", loginDetails.Password)
+	form.Values.Set("USER", loginDetails.Username)
+	form.Values.Set("PASSWORD", loginDetails.Password)
 	form.URL = makeAbsoluteURL(form.URL, loginDetails.URL)
 
 	req, err := form.BuildRequest()
@@ -223,7 +225,7 @@ func (ac *Client) handleWebAuthn(ctx context.Context, doc *goquery.Document) (co
 }
 
 func docIsLogin(doc *goquery.Document) bool {
-	return doc.Has("input[name=\"pf.pass\"]").Size() == 1
+	return doc.Has("input[name=\"pf.pass\"]").Size() == 1 || doc.Has("input[name=\"PASSWORD\"]").Size() == 1
 }
 
 func docIsOTP(doc *goquery.Document) bool {


### PR DESCRIPTION
in addition to recognizing `pf.username` and `pf.pass`, identifies `USER` and `PASSWORD` as alternatives in the
pingfed SAML login form