### PR TITLE
Adding SAML Assertion caching feature

### DIFF
--- a/README.md
+++ b/README.md
@@ -635,7 +635,9 @@ When using the aws cli with the `mybucket` profile, the authentication process w
 
 You can use the flag `--cache-saml` in order to cache the SAML assertion at authentication time. The SAML assertion cache has a very short validity (5 min) and can be used to authenticate to several roles with a single MFA validation.
 
-The cache name file is called `.saml2aws_cache` and is stored in your `.aws` directory in your user homedir.
+there is a file per saml2aws profile, the cache directory is called `.saml2aws_cache` and is located in your `.aws` directory in your user homedir.
+
+You can toggle `--cache-saml` during `login` or during `list-roles`, and you can set it once during `configure` and use it implicitly.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -635,7 +635,7 @@ When using the aws cli with the `mybucket` profile, the authentication process w
 
 You can use the flag `--cache-saml` in order to cache the SAML assertion at authentication time. The SAML assertion cache has a very short validity (5 min) and can be used to authenticate to several roles with a single MFA validation.
 
-there is a file per saml2aws profile, the cache directory is called `.saml2aws_cache` and is located in your `.aws` directory in your user homedir.
+there is a file per saml2aws profile, the cache directory is called `saml2aws` and is located in your `.aws` directory in your user homedir.
 
 You can toggle `--cache-saml` during `login` or during `list-roles`, and you can set it once during `configure` and use it implicitly.
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ The process goes something like this:
 * Prompt user for credentials
 * Log in to Identity Provider using form based authentication
 * Build a SAML assertion containing AWS roles
+* Optionally cache the SAML assertion
 * Exchange the role and SAML assertion with [AWS STS service](https://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html) to get a temporary set of credentials
 * Save these credentials to an aws profile named "saml"
 
@@ -629,6 +630,12 @@ credential_process = saml2aws login --skip-prompt --quiet --credential-process -
 ```
 
 When using the aws cli with the `mybucket` profile, the authentication process will be run and the aws will then be executed based on the returned credentials.
+
+# Caching the saml2aws SAML assertion for immediate reuse
+
+You can use the flag `--cache-saml` in order to cache the SAML assertion at authentication time. The SAML assertion cache has a very short validity (5 min) and can be used to authenticate to several roles with a single MFA validation.
+
+The cache name file is called `.saml2aws_cache` and is stored in your `.aws` directory in your user homedir.
 
 # License
 

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The process goes something like this:
 * Prompt user for credentials
 * Log in to Identity Provider using form based authentication
 * Build a SAML assertion containing AWS roles
-* Optionally cache the SAML assertion
+* Optionally cache the SAML assertion (the cache is not encrypted)
 * Exchange the role and SAML assertion with [AWS STS service](https://docs.aws.amazon.com/STS/latest/APIReference/Welcome.html) to get a temporary set of credentials
 * Save these credentials to an aws profile named "saml"
 

--- a/cmd/saml2aws/commands/list_roles.go
+++ b/cmd/saml2aws/commands/list_roles.go
@@ -25,7 +25,7 @@ func ListRoles(loginFlags *flags.LoginExecFlags) error {
 	}
 
 	// creates a cacheProvider, only used when --cache is set
-	cacheProvider := samlcache.NewSAMLCacheProvider(account.Profile, "")
+	cacheProvider := samlcache.NewSAMLCacheProvider(account.Name, "")
 
 	loginDetails, err := resolveLoginDetails(account, loginFlags)
 	if err != nil {

--- a/cmd/saml2aws/commands/list_roles.go
+++ b/cmd/saml2aws/commands/list_roles.go
@@ -25,7 +25,10 @@ func ListRoles(loginFlags *flags.LoginExecFlags) error {
 	}
 
 	// creates a cacheProvider, only used when --cache is set
-	cacheProvider := samlcache.NewSAMLCacheProvider(account.Name, "")
+	// cacheProvider := samlcache.NewSAMLCacheProvider(account.Name, "")
+	cacheProvider := &samlcache.SAMLCacheProvider{
+		Account: account.Name,
+	}
 
 	loginDetails, err := resolveLoginDetails(account, loginFlags)
 	if err != nil {
@@ -47,7 +50,7 @@ func ListRoles(loginFlags *flags.LoginExecFlags) error {
 
 	var samlAssertion string
 	if account.SAMLCache {
-		if valid, _ := cacheProvider.IsValid(); valid {
+		if cacheProvider.IsValid() {
 			samlAssertion, err = cacheProvider.Read()
 			if err != nil {
 				logger.Debug("Could not read cache:", err)

--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -33,7 +33,9 @@ func Login(loginFlags *flags.LoginExecFlags) error {
 
 	sharedCreds := awsconfig.NewSharedCredentials(account.Profile, account.CredentialsFile)
 	// creates a cacheProvider, only used when --cache is set
-	cacheProvider := samlcache.NewSAMLCacheProvider(account.Name, "")
+	cacheProvider := &samlcache.SAMLCacheProvider{
+		Account: account.Name,
+	}
 
 	logger.Debug("check if Creds Exist")
 
@@ -84,13 +86,13 @@ func Login(loginFlags *flags.LoginExecFlags) error {
 
 	var samlAssertion string
 	if account.SAMLCache {
-		if valid, err := cacheProvider.IsValid(); valid {
+		if cacheProvider.IsValid() {
 			samlAssertion, err = cacheProvider.Read()
 			if err != nil {
 				return errors.Wrap(err, "Could not read saml cache")
 			}
 		} else {
-			logger.Debug("Cache is invalid:", err)
+			logger.Debug("Cache is invalid")
 		}
 	}
 

--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -87,7 +87,7 @@ func Login(loginFlags *flags.LoginExecFlags) error {
 		if valid, err := cacheProvider.IsValid(); valid {
 			samlAssertion, err = cacheProvider.Read()
 			if err != nil {
-				logger.Debug("Could not read cache:", err)
+				return errors.Wrap(err, "Could not read saml cache")
 			}
 		} else {
 			logger.Debug("Cache is invalid:", err)
@@ -103,7 +103,7 @@ func Login(loginFlags *flags.LoginExecFlags) error {
 		if account.SAMLCache {
 			err = cacheProvider.Write(samlAssertion)
 			if err != nil {
-				logger.Error("Could not write samlAssertion:", err)
+				return errors.Wrap(err, "Could not write saml cache")
 			}
 		}
 	}

--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -33,7 +33,7 @@ func Login(loginFlags *flags.LoginExecFlags) error {
 
 	sharedCreds := awsconfig.NewSharedCredentials(account.Profile, account.CredentialsFile)
 	// creates a cacheProvider, only used when --cache is set
-	cacheProvider := samlcache.NewSAMLCacheProvider(account.Profile, "")
+	cacheProvider := samlcache.NewSAMLCacheProvider(account.Name, "")
 
 	logger.Debug("check if Creds Exist")
 

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -92,6 +92,7 @@ func main() {
 	cmdConfigure.Flag("profile", "The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)").Envar("SAML2AWS_PROFILE").Short('p').StringVar(&commonFlags.Profile)
 	cmdConfigure.Flag("resource-id", "F5APM SAML resource ID of your company account. (env: SAML2AWS_F5APM_RESOURCE_ID)").Envar("SAML2AWS_F5APM_RESOURCE_ID").StringVar(&commonFlags.ResourceID)
 	cmdConfigure.Flag("credentials-file", "The file that will cache the credentials retrieved from AWS. When not specified, will use the default AWS credentials file location. (env: SAML2AWS_CREDENTIALS_FILE)").Envar("SAML2AWS_CREDENTIALS_FILE").StringVar(&commonFlags.CredentialsFile)
+	cmdConfigure.Flag("cache-saml", "Caches the SAML response").Envar("SAML2AWS_CACHE_SAML").BoolVar(&commonFlags.SAMLCache)
 	configFlags := commonFlags
 
 	// `login` command and settings
@@ -105,6 +106,7 @@ func main() {
 	cmdLogin.Flag("force", "Refresh credentials even if not expired.").BoolVar(&loginFlags.Force)
 	cmdLogin.Flag("credential-process", "Enables AWS Credential Process support by outputting credentials to STDOUT in a JSON message.").BoolVar(&loginFlags.CredentialProcess)
 	cmdLogin.Flag("credentials-file", "The file that will cache the credentials retrieved from AWS. When not specified, will use the default AWS credentials file location. (env: SAML2AWS_CREDENTIALS_FILE)").Envar("SAML2AWS_CREDENTIALS_FILE").StringVar(&commonFlags.CredentialsFile)
+	cmdLogin.Flag("cache-saml", "Caches the SAML response").Envar("SAML2AWS_CACHE_SAML").BoolVar(&commonFlags.SAMLCache)
 
 	// `exec` command and settings
 	cmdExec := app.Command("exec", "Exec the supplied command with env vars from STS token.")
@@ -128,6 +130,7 @@ func main() {
 
 	// `list` command and settings
 	cmdListRoles := app.Command("list-roles", "List available role ARNs.")
+	cmdListRoles.Flag("cache-saml", "Caches the SAML response").Envar("SAML2AWS_CACHE_SAML").BoolVar(&commonFlags.SAMLCache)
 	listRolesFlags := new(flags.LoginExecFlags)
 	listRolesFlags.CommonFlags = commonFlags
 

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -30,6 +30,7 @@ const (
 
 // IDPAccount saml IDP account
 type IDPAccount struct {
+	Name                 string
 	AppID                string `ini:"app_id"` // used by OneLogin and AzureAD
 	URL                  string `ini:"url"`
 	Username             string `ini:"username"`
@@ -195,6 +196,9 @@ func (cm *ConfigManager) LoadIDPAccount(idpAccountName string) (*IDPAccount, err
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to read idp account")
 	}
+
+	// adding Name at Load time for the IdpAccount to have awareness of "self"
+	account.Name = idpAccountName
 
 	return account, nil
 }

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -47,6 +47,7 @@ type IDPAccount struct {
 	HttpAttemptsCount    string `ini:"http_attempts_count"`
 	HttpRetryDelay       string `ini:"http_retry_delay"`
 	CredentialsFile      string `ini:"credentials_file"`
+	SAMLCache            bool   `ini:"saml_cache"`
 }
 
 func (ia IDPAccount) String() string {

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -27,6 +27,7 @@ func TestNewConfigManagerLoad(t *testing.T) {
 	idpAccount, err := cfgm.LoadIDPAccount("test123")
 	require.Nil(t, err)
 	require.Equal(t, &IDPAccount{
+		Name:                 "test123",
 		URL:                  "https://id.whatever.com",
 		Username:             "abc@whatever.com",
 		Provider:             "keycloak",
@@ -61,6 +62,7 @@ func TestNewConfigManagerSave(t *testing.T) {
 	idpAccount, err := cfgm.LoadIDPAccount("testing2")
 	require.Nil(t, err)
 	require.Equal(t, &IDPAccount{
+		Name:                 "testing2",
 		URL:                  "https://id.whatever.com",
 		Username:             "abc@whatever.com",
 		Provider:             "keycloak",

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -28,6 +28,7 @@ type CommonFlags struct {
 	DisableKeychain      bool
 	Region               string
 	CredentialsFile      string
+	SAMLCache            bool
 }
 
 // LoginExecFlags flags for the Login / Exec commands
@@ -97,5 +98,8 @@ func ApplyFlagOverrides(commonFlags *CommonFlags, account *cfg.IDPAccount) {
 	}
 	if commonFlags.CredentialsFile != "" {
 		account.CredentialsFile = commonFlags.CredentialsFile
+	}
+	if commonFlags.SAMLCache {
+		account.SAMLCache = commonFlags.SAMLCache
 	}
 }

--- a/pkg/samlcache/samlcache.go
+++ b/pkg/samlcache/samlcache.go
@@ -1,0 +1,109 @@
+package samlcache
+
+import (
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	homedir "github.com/mitchellh/go-homedir"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	ErrInvalidCachePath = errors.New("Cannot evaluate Cache file path")
+	logger              = logrus.WithField("pkg", "samlcache")
+)
+
+const (
+	SAMLAssertionValidityTimeout = 5 * time.Minute
+	SAMLCachePermissions         = 0600
+	SAMLCacheFilename            = ".saml2aws_cache"
+)
+
+func resolveSymlink(filename string) (string, error) {
+	sympath, err := filepath.EvalSymlinks(filename)
+
+	// return the un modified filename
+	if os.IsNotExist(err) {
+		return filename, nil
+	}
+	if err != nil {
+		return "", err
+	}
+
+	return sympath, nil
+}
+
+func locateCacheFile() (string, error) {
+
+	var name string
+	var err error
+	if runtime.GOOS == "windows" {
+		name = path.Join(os.Getenv("USERPROFILE"), ".aws", SAMLCacheFilename)
+	} else {
+		name, err = homedir.Expand(path.Join("~", ".aws", SAMLCacheFilename))
+		if err != nil {
+			return "", ErrInvalidCachePath
+		}
+	}
+	// is the filename a symlink?
+	name, err = resolveSymlink(name)
+	if err != nil {
+		return "", errors.Wrap(err, "unable to resolve symlink")
+	}
+
+	logger.WithField("name", name).Debug("resolveSymlink")
+
+	return name, nil
+}
+
+func IsValidCache() bool {
+
+	cache_path, err := locateCacheFile()
+	if err != nil {
+		logger.Debug("Could not retrieve cache file path")
+		return false
+	}
+
+	fileInfo, err := os.Stat(cache_path)
+	if err != nil {
+		logger.Error("Could not access cache file info")
+		return false
+	}
+
+	return time.Since(fileInfo.ModTime()) < SAMLAssertionValidityTimeout
+}
+
+func ReadCache() (string, error) {
+
+	cache_path, err := locateCacheFile()
+	if err != nil {
+		return "", errors.Wrap(err, "Could not retrieve cache file path")
+	}
+
+	content, err := ioutil.ReadFile(cache_path)
+	if err != nil {
+		return "", errors.Wrap(err, "Could not read the cache file path")
+	}
+
+	return string(content), nil
+}
+
+func WriteCache(samlAssertion string) error {
+
+	cache_path, err := locateCacheFile()
+	if err != nil {
+		return errors.Wrap(err, "Could not retrieve cache file path")
+	}
+
+	err = ioutil.WriteFile(cache_path, []byte(samlAssertion), SAMLCachePermissions)
+	if err != nil {
+		return errors.Wrap(err, "Could not write the cache file path")
+	}
+
+	return nil
+}

--- a/pkg/samlcache/samlcache.go
+++ b/pkg/samlcache/samlcache.go
@@ -32,14 +32,6 @@ type SAMLCacheProvider struct {
 	Account  string
 }
 
-func NewSAMLCacheProvider(account string, filename string) *SAMLCacheProvider {
-	p := &SAMLCacheProvider{
-		Filename: filename,
-		Account:  account,
-	}
-	return p
-}
-
 func resolveSymlink(filename string) (string, error) {
 	sympath, err := filepath.EvalSymlinks(filename)
 
@@ -54,14 +46,13 @@ func resolveSymlink(filename string) (string, error) {
 	return sympath, nil
 }
 
-func (p *SAMLCacheProvider) IsValid() (bool, error) {
+func (p *SAMLCacheProvider) IsValid() bool {
 	var cache_path string
 	var err error
 	if p.Filename == "" {
 		cache_path, err = locateCacheFile(p.Account)
 		if err != nil {
-			logger.Debug("Could not retrieve cache file path")
-			return false, err
+			return false
 		}
 	} else {
 		cache_path = p.Filename
@@ -69,14 +60,10 @@ func (p *SAMLCacheProvider) IsValid() (bool, error) {
 
 	fileInfo, err := os.Stat(cache_path)
 	if err != nil {
-		return false, errors.Wrap(err, "Could not access cache file info")
+		return false
 	}
 
-	if time.Since(fileInfo.ModTime()) < SAMLAssertionValidityTimeout {
-		return true, nil
-	} else {
-		return false, errors.New("Cache is expired")
-	}
+	return time.Since(fileInfo.ModTime()) < SAMLAssertionValidityTimeout
 }
 
 func locateCacheFile(account string) (string, error) {

--- a/pkg/samlcache/samlcache.go
+++ b/pkg/samlcache/samlcache.go
@@ -23,7 +23,7 @@ const (
 	SAMLAssertionValidityTimeout = 5 * time.Minute
 	SAMLCacheFilePermissions     = 0600
 	SAMLCacheDirPermissions      = 0700
-	SAMLCacheDir                 = ".saml2aws_cache"
+	SAMLCacheDir                 = "saml2aws"
 )
 
 // SAMLCacheProvider  loads aws credentials file

--- a/pkg/samlcache/samlcache_test.go
+++ b/pkg/samlcache/samlcache_test.go
@@ -91,10 +91,8 @@ func TestIsValid(t *testing.T) {
 		Filename: "example_cache",
 	}
 
-	var valid bool
-	var err error
-	if valid, err = p.IsValid(); !valid {
-		t.Error("Cache file is not valid!", err)
+	if !p.IsValid() {
+		t.Error("Cache file is not valid!")
 	}
 
 	// changing the file timestamp to validate expiry
@@ -102,7 +100,7 @@ func TestIsValid(t *testing.T) {
 	new_time := time.Now().Add(-24 * time.Hour)
 	_ = os.Chtimes("example_cache", new_time, new_time)
 
-	if valid, _ = p.IsValid(); valid {
+	if p.IsValid() {
 		t.Error("Cache file should be expired!")
 	}
 

--- a/pkg/samlcache/samlcache_test.go
+++ b/pkg/samlcache/samlcache_test.go
@@ -1,0 +1,40 @@
+package samlcache
+
+import (
+	"os"
+	"testing"
+)
+
+func TestLocateCache(t *testing.T) {
+
+	cache_location, err := locateCacheFile()
+	if err != nil {
+		t.Errorf("Could not locate cache file: %v", err)
+	}
+
+	if cache_location == "" {
+		t.Errorf("Retrieved location is empty")
+	}
+
+}
+
+func TestCanWriteAndRead(t *testing.T) {
+
+	cache_location, _ := locateCacheFile()
+
+	err := WriteCache("test_write_cache")
+	if err != nil {
+		t.Errorf("Could not write cache: %v", err)
+	}
+
+	content, err := ReadCache()
+	if err != nil {
+		t.Errorf("Could not read cache: %v", err)
+	}
+	if content != "test_write_cache" {
+		t.Errorf("Content is not as expected: %v", content)
+	}
+
+	os.Remove(cache_location)
+
+}

--- a/pkg/samlcache/samlcache_test.go
+++ b/pkg/samlcache/samlcache_test.go
@@ -1,40 +1,83 @@
 package samlcache
 
 import (
+	"io/ioutil"
 	"os"
+	"path"
 	"testing"
 )
 
-func TestLocateCache(t *testing.T) {
+func TestLocateCacheDefault(t *testing.T) {
 
-	cache_location, err := locateCacheFile()
+	cache_location, err := locateCacheFile("")
 	if err != nil {
-		t.Errorf("Could not locate cache file: %v", err)
+		t.Error("Could not locate cache file:", err)
 	}
 
 	if cache_location == "" {
-		t.Errorf("Retrieved location is empty")
+		t.Error("Retrieved location is empty")
+	}
+
+	if path.Base(cache_location) != "cache" {
+		t.Error("Filename is not the default one (cache):", path.Base(cache_location))
 	}
 
 }
 
-func TestCanWriteAndRead(t *testing.T) {
+func TestLocateCacheAccount(t *testing.T) {
 
-	cache_location, _ := locateCacheFile()
-
-	err := WriteCache("test_write_cache")
+	cache_location, err := locateCacheFile("myaccount")
 	if err != nil {
-		t.Errorf("Could not write cache: %v", err)
+		t.Error("Could not locate cache file:", err)
 	}
 
-	content, err := ReadCache()
+	if cache_location == "" {
+		t.Error("Retrieved location is empty")
+	}
+
+	if path.Base(cache_location) != "cache_myaccount" {
+		t.Error("Filename is not the default one (cache_myaccount):", path.Base(cache_location))
+	}
+
+}
+
+func TestCanWrite(t *testing.T) {
+
+	p := SAMLCacheProvider{
+		Filename: "testdir/cache_file",
+	}
+
+	err := p.Write("test_write_cache")
 	if err != nil {
-		t.Errorf("Could not read cache: %v", err)
-	}
-	if content != "test_write_cache" {
-		t.Errorf("Content is not as expected: %v", content)
+		t.Error("Could not write cache:", err)
 	}
 
-	os.Remove(cache_location)
+	if _, err := os.Stat("testdir/cache_file"); os.IsNotExist(err) {
+		t.Error("The cache file was not created:", err)
+	}
+
+	os.RemoveAll("testdir")
+
+}
+
+func TestCanRead(t *testing.T) {
+
+	// create a dummy file
+	_ = ioutil.WriteFile("example_cache", []byte("testing output"), 0700)
+
+	p := SAMLCacheProvider{
+		Filename: "example_cache",
+	}
+
+	output, err := p.Read()
+	if err != nil {
+		t.Error("Could not read cache:", err)
+	}
+
+	if output != "testing output" {
+		t.Error("Cache file does not contain the right thing", output)
+	}
+
+	os.Remove("example_cache")
 
 }

--- a/pkg/samlcache/samlcache_test.go
+++ b/pkg/samlcache/samlcache_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path"
 	"testing"
+	"time"
 )
 
 func TestLocateCacheDefault(t *testing.T) {
@@ -76,6 +77,33 @@ func TestCanRead(t *testing.T) {
 
 	if output != "testing output" {
 		t.Error("Cache file does not contain the right thing", output)
+	}
+
+	os.Remove("example_cache")
+
+}
+
+func TestIsValid(t *testing.T) {
+
+	// create a dummy file
+	_ = ioutil.WriteFile("example_cache", []byte("testing output"), 0700)
+	p := SAMLCacheProvider{
+		Filename: "example_cache",
+	}
+
+	var valid bool
+	var err error
+	if valid, err = p.IsValid(); !valid {
+		t.Error("Cache file is not valid!", err)
+	}
+
+	// changing the file timestamp to validate expiry
+	// new_time := time.Now().Sub(24 * time.Hour)
+	new_time := time.Now().Add(-24 * time.Hour)
+	_ = os.Chtimes("example_cache", new_time, new_time)
+
+	if valid, _ = p.IsValid(); valid {
+		t.Error("Cache file should be expired!")
 	}
 
 	os.Remove("example_cache")


### PR DESCRIPTION
You can now cache the SAML assertion after authentication using the flag
`--cache-saml`. You can use the flag at `configure` time and it will be
set on subsequent `login` and `list-roles` calls.

The timeout for a SAML assertion is set to 5min as a constant, and the
code makes it relatively easy to make it configurable if needed, like
for example override this per provider.

Fixes #526