### PR TITLE
Change macOS install instruction to install from homebrew-core

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,6 @@ Aside from Okta, most of the providers in this project are using screen scraping
 If you're on OSX you can install saml2aws using homebrew!
 
 ```
-brew tap versent/homebrew-taps
 brew install saml2aws
 saml2aws --version
 ```


### PR DESCRIPTION
Congratulations! `saml2aws` has been added to [homebrew-core](https://github.com/Homebrew/homebrew-core). Therefore, it can be installed right away with `brew install saml2aws` without having to add a tap.

Do you also want me to add a `tap_migrations.json` file to your own tap that will automatically migrate all installations to `homebrew-core`? (see https://docs.brew.sh/Migrating-A-Formula-To-A-Tap)