### PR TITLE
readme: Added profile in credential process

### DIFF
--- a/README.md
+++ b/README.md
@@ -616,7 +616,7 @@ An example of the aws configuration (`~/.aws/config`):
 ```
 [profile mybucket]
 region = us-west-1
-credential_process = saml2aws login --skip-prompt --quiet --credential-process --role <ROLE>
+credential_process = saml2aws login --skip-prompt --quiet --credential-process --role <ROLE> --profile mybucket
 ```
 
 When using the aws cli with the `mybucket` profile, the authentication process will be run and the aws will then be executed based on the returned credentials.


### PR DESCRIPTION
It seems that by skipping --profile flag in credential_process authentication, saml2aws will use [saml] profile in `~/.aws/credentials` to store the temp keys. 

This could lead to the situation where person was authenticated in account A, credentials hasn't expired yet -> they are not renewed -> account A details are used, even though we want to access account B.