### PR TITLE
Adding Tests and local builds to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,22 @@ lint-fix: $(BIN_DIR)/golangci-lint
 
 fmt: lint-fix
 
+test:
+	@$(BIN_DIR)/gocov test $(SOURCE_FILES) | $(BIN_DIR)/gocov report
+
+local-compile: mod
+	@rm -rf build/
+	@$(BIN_DIR)/gox -ldflags "-X main.Version=$(VERSION)" \
+	-osarch="darwin/amd64" \
+	-osarch="linux/i386" \
+	-osarch="linux/amd64" \
+	-osarch="windows/amd64" \
+	-osarch="windows/i386" \
+	-output "build/{{.Dir}}_$(VERSION)_{{.OS}}_{{.Arch}}/$(NAME)" \
+	${SOURCE_FILES}
+
+local-build: lint test local-compile
+
 install:
 	go install ./cmd/saml2aws
 

--- a/README.md
+++ b/README.md
@@ -535,6 +535,7 @@ To build this software on osx clone to the repo to `$GOPATH/src/github.com/verse
 
 ```
 make mod
+make local-build
 ```
 
 Install the binary to `$GOPATH/bin`.
@@ -592,12 +593,6 @@ Install `github-release`.
 
 ```
 go get github.com/buildkite/github-release
-```
-
-To release run.
-
-```
-make release
 ```
 
 # Debugging Issues with IDPs


### PR DESCRIPTION
The builds and testing have been taken off the makefile and added to the
CI, it's also convenient to run those during local development.

Re-adding them in a different name and changed the documentation.