### PR TITLE
Add Webauthn and Duo support for JumpCloud

### DIFF
--- a/pkg/provider/jumpcloud/jumpcloud_webauthn.go
+++ b/pkg/provider/jumpcloud/jumpcloud_webauthn.go
@@ -1,0 +1,192 @@
+package jumpcloud
+
+import (
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"time"
+
+	"github.com/marshallbrekka/go-u2fhost"
+)
+
+const (
+	MaxOpenRetries = 10
+	RetryDelayMS   = 200 * time.Millisecond
+
+	jumpCloudOrigin = "https://console.jumpcloud.com"
+)
+
+var (
+	errNoDeviceFound = fmt.Errorf("no U2F devices found. device might not be plugged in")
+)
+
+// FidoClient represents a challenge and the device used to respond
+type FidoClient struct {
+	challenge string
+	rpId      string
+	keyHandle string
+	token     string
+
+	Device u2fhost.Device
+}
+
+type JumpCloudResponse struct {
+	PublicKeyCredential PublicKey `json:"publicKeyCredential"`
+	Token               string    `json:"token"`
+}
+
+type PublicKey struct {
+	Id       string            `json:"id"`
+	RawId    string            `json:"rawId"`
+	Type     string            `json:"type"`
+	Response PublicKeyResponse `json:"response"`
+}
+
+type PublicKeyResponse struct {
+	ClientData        string  `json:"clientDataJSON"`
+	AuthenticatorData string  `json:"authenticatorData"`
+	SignatureData     string  `json:"signature"`
+	UserHandle        *string `json:"userHandle"`
+}
+
+// DeviceFinder is used to mock out finding devices
+type DeviceFinder interface {
+	findDevice() (u2fhost.Device, error)
+}
+
+// U2FDevice is used to support mocking this device with mockery https://github.com/vektra/mockery/issues/210#issuecomment-485026348
+type U2FDevice interface {
+	u2fhost.Device
+}
+
+// NewFidoClient returns a new initialized FIDO1-based WebAuthnClient, representing a single device
+func NewFidoClient(challenge, rpId, keyHandle, token string, deviceFinder DeviceFinder) (FidoClient, error) {
+	var device u2fhost.Device
+	var err error
+
+	retryCount := 0
+	for retryCount < MaxOpenRetries {
+		device, err = deviceFinder.findDevice()
+		if err != nil {
+			if err == errNoDeviceFound {
+				return FidoClient{}, err
+			}
+
+			retryCount++
+			time.Sleep(RetryDelayMS)
+			continue
+		}
+
+		return FidoClient{
+			Device:    device,
+			challenge: challenge,
+			rpId:      rpId,
+			keyHandle: keyHandle,
+			token:     token,
+		}, nil
+	}
+
+	return FidoClient{}, fmt.Errorf("failed to create client: %s. exceeded max retries of %d", err, MaxOpenRetries)
+}
+
+// ChallengeU2F takes a FidoClient and returns a signed assertion to send to Okta
+func (d *FidoClient) ChallengeU2F() (*JumpCloudResponse, error) {
+	if d.Device == nil {
+		return nil, errors.New("No Device Found")
+	}
+	request := &u2fhost.AuthenticateRequest{
+		Challenge: d.challenge,
+		Facet:     jumpCloudOrigin,
+		AppId:     d.rpId,
+		KeyHandle: d.keyHandle,
+		WebAuthn:  true,
+	}
+	// do the change
+	prompted := false
+	timeout := time.After(time.Second * 25)
+	interval := time.NewTicker(time.Millisecond * 250)
+	var responsePayload *JumpCloudResponse
+
+	defer func() {
+		d.Device.Close()
+	}()
+	defer interval.Stop()
+	for {
+		select {
+		case <-timeout:
+			return nil, errors.New("Failed to get authentication response after 25 seconds")
+		case <-interval.C:
+			response, err := d.Device.Authenticate(request)
+			if err == nil {
+				authenticatorData, err := urlEncode(response.AuthenticatorData)
+				if err != nil {
+					return nil, err
+				}
+				signatureData, err := urlEncode(response.SignatureData)
+				if err != nil {
+					return nil, err
+				}
+				responsePayload = &JumpCloudResponse{
+					PublicKeyCredential: PublicKey{
+						Id:    response.KeyHandle,
+						RawId: response.KeyHandle,
+						Type:  "public-key",
+						Response: PublicKeyResponse{
+							ClientData:        response.ClientData,
+							AuthenticatorData: authenticatorData,
+							SignatureData:     signatureData,
+							UserHandle:        nil,
+						},
+					},
+					Token: d.token,
+				}
+				fmt.Printf("  ==> Touch accepted. Proceeding with authentication\n")
+				return responsePayload, nil
+			}
+
+			switch err.(type) {
+			case *u2fhost.TestOfUserPresenceRequiredError:
+				if !prompted {
+					fmt.Printf("\nTouch the flashing U2F device to authenticate...\n")
+					prompted = true
+				}
+			default:
+				return responsePayload, err
+			}
+		}
+	}
+
+}
+
+func urlEncode(stdEncodedStr string) (string, error) {
+	decodedStr, err := base64.StdEncoding.DecodeString(stdEncodedStr)
+	if err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(decodedStr), nil
+}
+
+// U2FDeviceFinder returns a U2F device
+type U2FDeviceFinder struct{}
+
+func (*U2FDeviceFinder) findDevice() (u2fhost.Device, error) {
+	var err error
+
+	allDevices := u2fhost.Devices()
+	if len(allDevices) == 0 {
+		return nil, errNoDeviceFound
+	}
+
+	for i, device := range allDevices {
+		err = device.Open()
+		if err != nil {
+			device.Close()
+
+			continue
+		}
+
+		return allDevices[i], nil
+	}
+
+	return nil, fmt.Errorf("failed to open fido U2F device: %s", err)
+}

--- a/pkg/provider/jumpcloud/jumpcloud_webauthn_test.go
+++ b/pkg/provider/jumpcloud/jumpcloud_webauthn_test.go
@@ -1,0 +1,85 @@
+package jumpcloud
+
+import (
+	"testing"
+
+	u2fhost "github.com/marshallbrekka/go-u2fhost"
+	"github.com/stretchr/testify/assert"
+	"github.com/versent/saml2aws/v2/mocks"
+)
+
+type fidoClientTests struct {
+	title string
+	err   error
+}
+
+type MockDeviceFinder struct {
+	device *mocks.U2FDevice
+}
+
+func (m *MockDeviceFinder) findDevice() (u2fhost.Device, error) {
+	return m.device, nil
+}
+
+func TestNewFidoClient(t *testing.T) {
+	challengeNonce := "challengeNonce"
+	rpId := "rpId"
+	keyHandle := "keyHandle"
+	token := "token"
+	tests := []fidoClientTests{
+		{
+			title: "Returns new client successfully if device found",
+			err:   nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			_, err := NewFidoClient(challengeNonce, rpId, keyHandle, token, &MockDeviceFinder{&mocks.U2FDevice{}})
+			if test.err != nil {
+				assert.NotNil(t, err)
+				assert.Equal(t, test.err.Error(), err.Error())
+			}
+		})
+	}
+}
+
+func TestChallengeU2F(t *testing.T) {
+	challengeNonce := "challengeNonce"
+	rpId := "rpId"
+	keyHandle := "keyHandle"
+	token := "token"
+	tests := []fidoClientTests{
+		{
+			title: "Returns signed assertion from device",
+			err:   nil,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.title, func(t *testing.T) {
+			device := &mocks.U2FDevice{}
+			mockDeviceFinder := &MockDeviceFinder{device}
+			device.On("Open").Return(nil)
+			request := &u2fhost.AuthenticateRequest{
+				Challenge:          challengeNonce,
+				AppId:              rpId,
+				Facet:              jumpCloudOrigin,
+				KeyHandle:          keyHandle,
+				ChannelIdPublicKey: nil,
+				ChannelIdUnused:    false,
+				CheckOnly:          false,
+				WebAuthn:           true,
+			}
+			response := &u2fhost.AuthenticateResponse{}
+			device.On("Authenticate", request).Return(response, nil)
+			device.On("Close").Return(nil)
+			client, _ := NewFidoClient(challengeNonce, rpId, keyHandle, token, mockDeviceFinder)
+			_, err := client.ChallengeU2F()
+			if test.err != nil {
+				assert.NotNil(t, err)
+				assert.Equal(t, test.err.Error(), err.Error())
+			}
+		})
+	}
+}

--- a/saml2aws.go
+++ b/saml2aws.go
@@ -35,7 +35,7 @@ var MFAsByProvider = ProviderList{
 	"ADFS2":         []string{"Auto", "RSA"}, // nothing automatic about ADFS 2.x
 	"Ping":          []string{"Auto"},        // automatically detects PingID
 	"PingOne":       []string{"Auto"},        // automatically detects PingID
-	"JumpCloud":     []string{"Auto"},
+	"JumpCloud":     []string{"Auto", "TOTP", "WEBAUTHN"},
 	"Okta":          []string{"Auto", "PUSH", "DUO", "SMS", "TOTP", "OKTA", "FIDO", "YUBICO TOKEN:HARDWARE"}, // automatically detects DUO, SMS, ToTP, and FIDO
 	"OneLogin":      []string{"Auto", "OLP", "SMS", "TOTP", "YUBIKEY"},                                       // automatically detects OneLogin Protect, SMS and ToTP
 	"KeyCloak":      []string{"Auto"},                                                                        // automatically detects ToTP

--- a/saml2aws.go
+++ b/saml2aws.go
@@ -35,7 +35,7 @@ var MFAsByProvider = ProviderList{
 	"ADFS2":         []string{"Auto", "RSA"}, // nothing automatic about ADFS 2.x
 	"Ping":          []string{"Auto"},        // automatically detects PingID
 	"PingOne":       []string{"Auto"},        // automatically detects PingID
-	"JumpCloud":     []string{"Auto", "TOTP", "WEBAUTHN"},
+	"JumpCloud":     []string{"Auto", "TOTP", "WEBAUTHN", "DUO"},
 	"Okta":          []string{"Auto", "PUSH", "DUO", "SMS", "TOTP", "OKTA", "FIDO", "YUBICO TOKEN:HARDWARE"}, // automatically detects DUO, SMS, ToTP, and FIDO
 	"OneLogin":      []string{"Auto", "OLP", "SMS", "TOTP", "YUBIKEY"},                                       // automatically detects OneLogin Protect, SMS and ToTP
 	"KeyCloak":      []string{"Auto"},                                                                        // automatically detects ToTP


### PR DESCRIPTION
* Adds support of devices like Yubikey via [WebAuthn ](https://fidoalliance.org/fido2/fido2-web-authentication-webauthn/)
* Adds support of [Duo 2fa](https://duo.com/) authentication 

should address #390 

- Copied some code from Okta with modifications, works with Yubikey
- Inspired by https://github.com/Versent/saml2aws/pull/489 
- Tested all three (TOTP, Duo and Yubikey) seems to be working.

Menu looks like that 
![image](https://user-images.githubusercontent.com/1124779/109459798-9c99ec80-7ab3-11eb-9442-600a4d56019d.png)

And here is similar to Okta FIDO prompt to press flashing key.

![image](https://user-images.githubusercontent.com/1124779/109383985-18722880-793e-11eb-8a02-b75885b84062.png)

Duo auth menu similar to Okta
![image](https://user-images.githubusercontent.com/1124779/109459752-855aff00-7ab3-11eb-9fde-fe99e4bd6d3d.png)


