### PR TITLE
Adding SAML cache file path option

### DIFF
--- a/README.md
+++ b/README.md
@@ -157,6 +157,8 @@ Commands:
     -p, --profile=PROFILE          The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)
         --resource-id=RESOURCE-ID  F5APM SAML resource ID of your company account. (env: SAML2AWS_F5APM_RESOURCE_ID)
         --config=CONFIG            Path/filename of saml2aws config file (env: SAML2AWS_CONFIGFILE)
+        --cache-saml               Caches the SAML response (env: SAML2AWS_CACHE_SAML)
+        --cache-file=CACHE-FILE    The location of the SAML cache file (env: SAML2AWS_SAML_CACHE_FILE)
 
   login [<flags>]
     Login to a SAML 2.0 IDP and convert the SAML assertion to an STS token.
@@ -171,6 +173,9 @@ Commands:
         --credential-process     Enables AWS Credential Process support by outputting credentials to STDOUT in a JSON message.
         --credentials-file=CREDENTIALS-FILE
                                  The file that will cache the credentials retrieved from AWS. When not specified, will use the default AWS credentials file location. (env: SAML2AWS_CREDENTIALS_FILE)
+        --cache-saml             Caches the SAML response (env: SAML2AWS_CACHE_SAML)
+        --cache-file=CACHE-FILE  The location of the SAML cache file (env: SAML2AWS_SAML_CACHE_FILE)
+
 
   exec [<flags>] [<command>...]
     Exec the supplied command with env vars from STS token.
@@ -194,6 +199,8 @@ Commands:
 
   list-roles
     List available role ARNs.
+        --cache-saml             Caches the SAML response (env: SAML2AWS_CACHE_SAML)
+        --cache-file=CACHE-FILE  The location of the SAML cache file (env: SAML2AWS_SAML_CACHE_FILE)
 
 
   script [<flags>]

--- a/cmd/saml2aws/commands/list_roles.go
+++ b/cmd/saml2aws/commands/list_roles.go
@@ -25,9 +25,9 @@ func ListRoles(loginFlags *flags.LoginExecFlags) error {
 	}
 
 	// creates a cacheProvider, only used when --cache is set
-	// cacheProvider := samlcache.NewSAMLCacheProvider(account.Name, "")
 	cacheProvider := &samlcache.SAMLCacheProvider{
-		Account: account.Name,
+		Account:  account.Name,
+		Filename: account.SAMLCacheFile,
 	}
 
 	loginDetails, err := resolveLoginDetails(account, loginFlags)

--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -34,7 +34,8 @@ func Login(loginFlags *flags.LoginExecFlags) error {
 	sharedCreds := awsconfig.NewSharedCredentials(account.Profile, account.CredentialsFile)
 	// creates a cacheProvider, only used when --cache is set
 	cacheProvider := &samlcache.SAMLCacheProvider{
-		Account: account.Name,
+		Account:  account.Name,
+		Filename: account.SAMLCacheFile,
 	}
 
 	logger.Debug("check if Creds Exist")

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -92,7 +92,8 @@ func main() {
 	cmdConfigure.Flag("profile", "The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)").Envar("SAML2AWS_PROFILE").Short('p').StringVar(&commonFlags.Profile)
 	cmdConfigure.Flag("resource-id", "F5APM SAML resource ID of your company account. (env: SAML2AWS_F5APM_RESOURCE_ID)").Envar("SAML2AWS_F5APM_RESOURCE_ID").StringVar(&commonFlags.ResourceID)
 	cmdConfigure.Flag("credentials-file", "The file that will cache the credentials retrieved from AWS. When not specified, will use the default AWS credentials file location. (env: SAML2AWS_CREDENTIALS_FILE)").Envar("SAML2AWS_CREDENTIALS_FILE").StringVar(&commonFlags.CredentialsFile)
-	cmdConfigure.Flag("cache-saml", "Caches the SAML response").Envar("SAML2AWS_CACHE_SAML").BoolVar(&commonFlags.SAMLCache)
+	cmdConfigure.Flag("cache-saml", "Caches the SAML response (env: SAML2AWS_CACHE_SAML)").Envar("SAML2AWS_CACHE_SAML").BoolVar(&commonFlags.SAMLCache)
+	cmdConfigure.Flag("cache-file", "The location of the SAML cache file (env: SAML2AWS_SAML_CACHE_FILE)").Envar("SAML2AWS_SAML_CACHE_FILE").StringVar(&commonFlags.SAMLCacheFile)
 	configFlags := commonFlags
 
 	// `login` command and settings
@@ -106,7 +107,8 @@ func main() {
 	cmdLogin.Flag("force", "Refresh credentials even if not expired.").BoolVar(&loginFlags.Force)
 	cmdLogin.Flag("credential-process", "Enables AWS Credential Process support by outputting credentials to STDOUT in a JSON message.").BoolVar(&loginFlags.CredentialProcess)
 	cmdLogin.Flag("credentials-file", "The file that will cache the credentials retrieved from AWS. When not specified, will use the default AWS credentials file location. (env: SAML2AWS_CREDENTIALS_FILE)").Envar("SAML2AWS_CREDENTIALS_FILE").StringVar(&commonFlags.CredentialsFile)
-	cmdLogin.Flag("cache-saml", "Caches the SAML response").Envar("SAML2AWS_CACHE_SAML").BoolVar(&commonFlags.SAMLCache)
+	cmdLogin.Flag("cache-saml", "Caches the SAML response (env: SAML2AWS_CACHE_SAML)").Envar("SAML2AWS_CACHE_SAML").BoolVar(&commonFlags.SAMLCache)
+	cmdLogin.Flag("cache-file", "The location of the SAML cache file (env: SAML2AWS_SAML_CACHE_FILE)").Envar("SAML2AWS_SAML_CACHE_FILE").StringVar(&commonFlags.SAMLCacheFile)
 
 	// `exec` command and settings
 	cmdExec := app.Command("exec", "Exec the supplied command with env vars from STS token.")
@@ -130,7 +132,8 @@ func main() {
 
 	// `list` command and settings
 	cmdListRoles := app.Command("list-roles", "List available role ARNs.")
-	cmdListRoles.Flag("cache-saml", "Caches the SAML response").Envar("SAML2AWS_CACHE_SAML").BoolVar(&commonFlags.SAMLCache)
+	cmdListRoles.Flag("cache-saml", "Caches the SAML response (env: SAML2AWS_CACHE_SAML)").Envar("SAML2AWS_CACHE_SAML").BoolVar(&commonFlags.SAMLCache)
+	cmdListRoles.Flag("cache-file", "The location of the SAML cache file (env: SAML2AWS_SAML_CACHE_FILE)").Envar("SAML2AWS_SAML_CACHE_FILE").StringVar(&commonFlags.SAMLCacheFile)
 	listRolesFlags := new(flags.LoginExecFlags)
 	listRolesFlags.CommonFlags = commonFlags
 

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -30,7 +30,7 @@ const (
 
 // IDPAccount saml IDP account
 type IDPAccount struct {
-	Name                 string
+	Name                 string `ini:"name"`
 	AppID                string `ini:"app_id"` // used by OneLogin and AzureAD
 	URL                  string `ini:"url"`
 	Username             string `ini:"username"`
@@ -49,6 +49,7 @@ type IDPAccount struct {
 	HttpRetryDelay       string `ini:"http_retry_delay"`
 	CredentialsFile      string `ini:"credentials_file"`
 	SAMLCache            bool   `ini:"saml_cache"`
+	SAMLCacheFile        string `ini:"saml_cache_file"`
 }
 
 func (ia IDPAccount) String() string {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -29,6 +29,7 @@ type CommonFlags struct {
 	Region               string
 	CredentialsFile      string
 	SAMLCache            bool
+	SAMLCacheFile        string
 }
 
 // LoginExecFlags flags for the Login / Exec commands
@@ -101,5 +102,8 @@ func ApplyFlagOverrides(commonFlags *CommonFlags, account *cfg.IDPAccount) {
 	}
 	if commonFlags.SAMLCache {
 		account.SAMLCache = commonFlags.SAMLCache
+	}
+	if commonFlags.SAMLCacheFile != "" {
+		account.SAMLCacheFile = commonFlags.SAMLCacheFile
 	}
 }


### PR DESCRIPTION
Extra fixing of #526, allows to override the SAML cache file location in lieu of the default one.
Will allow different IDPAccount configurations to share a single SAML cache file.

Added to the documentation.
Fixed a Marshalling inconsistency with IDPAccount where Name is stored with
a capital lettter.