### PR TITLE
Support Shibboleth IdP v4 with CSRF tokens

### DIFF
--- a/pkg/provider/shibboleth/README.md
+++ b/pkg/provider/shibboleth/README.md
@@ -13,4 +13,6 @@ https://idp.example.com/idp/profile/SAML2/Unsolicited/SSO?providerId=urn:amazon:
 
 ## Limitations
 
-* Has only been tested with Shibboleth 3.3 with Duo MFA enabled.
+* Tested on:
+ * Shibboleth 3.3 with Duo MFA;
+ * Shibboleth 4.0.1 with Duo MFA and CSRF tokens.

--- a/pkg/provider/shibboleth/shibboleth.go
+++ b/pkg/provider/shibboleth/shibboleth.go
@@ -145,7 +145,7 @@ func updateFormData(authForm url.Values, s *goquery.Selection, user *creds.Login
 
 func verifyMfa(oc *Client, shibbolethHost string, resp string) (*http.Response, error) {
 
-	duoHost, postAction, tx, app := parseTokens(resp)
+	duoHost, postAction, tx, app, csrfToken := parseTokens(resp)
 
 	parent := fmt.Sprintf(shibbolethHost + postAction)
 
@@ -157,6 +157,7 @@ func verifyMfa(oc *Client, shibbolethHost string, resp string) (*http.Response, 
 	idpForm := url.Values{}
 	idpForm.Add("_eventId", "proceed")
 	idpForm.Add("sig_response", duoTxCookie+":"+app)
+	idpForm.Add("csrf_token", csrfToken)
 
 	req, err := http.NewRequest("POST", parent, strings.NewReader(idpForm.Encode()))
 	if err != nil {
@@ -376,17 +377,25 @@ func verifyDuoMfa(oc *Client, duoHost string, parent string, tx string) (string,
 	return duoTxCookie, nil
 }
 
-func parseTokens(blob string) (string, string, string, string) {
+func parseTokens(blob string) (string, string, string, string, string) {
 	hostRgx := regexp.MustCompile(`data-host=\"(.*?)\"`)
 	sigRgx := regexp.MustCompile(`data-sig-request=\"(.*?)\"`)
 	dpaRgx := regexp.MustCompile(`data-post-action=\"(.*?)\"`)
+	csrfRgx := regexp.MustCompile(`name=\"csrf_token\" value=\"(.*?)\"`)
 
 	dataSigRequest := sigRgx.FindStringSubmatch(blob)
 	duoHost := hostRgx.FindStringSubmatch(blob)
 	postAction := dpaRgx.FindStringSubmatch(blob)
 
+	// extract the Shibboleth v4 CSRF token, if present
+	csrfToken := ""
+	csrfTokenMatch := csrfRgx.FindStringSubmatch(blob)
+	if len(csrfTokenMatch) != 0 {
+		csrfToken = csrfTokenMatch[1]
+	}
+
 	duoSignatures := strings.Split(dataSigRequest[1], ":")
-	return duoHost[1], postAction[1], duoSignatures[0], duoSignatures[1]
+	return duoHost[1], postAction[1], duoSignatures[0], duoSignatures[1], csrfToken
 }
 
 func extractSamlResponse(res *http.Response) (string, error) {


### PR DESCRIPTION
Shibboleth IdP v4 introduced a CSRF token as part of the login flow. Using the Shibboleth provider against a v4 IdP with the CSRF token enabled results in an error (see #638).

This PR extracts the CSRF token and includes it in subsequent responses.