### PR TITLE
Adding ENV as a script output

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Commands:
     Emit a script that will export environment variables.
 
     -p, --profile=PROFILE      The AWS profile to save the temporary credentials. (env: SAML2AWS_PROFILE)
-        --shell=bash           Type of shell environment. Options include: bash, powershell, fish
+        --shell=bash           Type of shell environment. Options include: bash, powershell, fish, env
         --credentials-file=CREDENTIALS-FILE
                                The file that will cache the credentials retrieved from AWS. When not specified, will use the default AWS credentials file location. (env: SAML2AWS_CREDENTIALS_FILE)
 
@@ -221,6 +221,7 @@ SAML2AWS_PROFILE=saml
 ```
 
 Powershell, and fish shells are supported as well.
+Env is useful for all AWS SDK compatible tools that can source an env file. It is a powerful combo with docker and the `--env-file` parameter.
 
 If you use `eval $(saml2aws script)` frequently, you may want to create a alias for it:
 
@@ -232,6 +233,11 @@ alias s2a="function(){eval $( $(command saml2aws) script --shell=bash --profile=
 bash:
 ```
 function s2a { eval $( $(which saml2aws) script --shell=bash --profile=$@); }
+```
+
+env:
+```
+docker run -ti --env-file <(saml2aws script --shell=env) amazon/aws-cli s3 ls
 ```
 
 ### `saml2aws exec`

--- a/cmd/saml2aws/commands/script.go
+++ b/cmd/saml2aws/commands/script.go
@@ -1,8 +1,9 @@
 package commands
 
 import (
+	"bytes"
+	"fmt"
 	"log"
-	"os"
 	"text/template"
 	"time"
 
@@ -33,6 +34,13 @@ $env:AWS_SESSION_TOKEN='{{ .AWSSessionToken }}'
 $env:AWS_SECURITY_TOKEN='{{ .AWSSecurityToken }}'
 $env:SAML2AWS_PROFILE='{{ .ProfileName }}'
 $env:AWS_CREDENTIAL_EXPIRATION='{{ .Expires.Format "2006-01-02T15:04:05Z07:00" }}'
+`
+
+const envTmpl = `AWS_ACCESS_KEY_ID={{ .AWSAccessKey }}
+AWS_SECRET_ACCESS_KEY={{ .AWSSecretKey }}
+AWS_SESSION_TOKEN={{ .AWSSessionToken }}
+AWS_SECURITY_TOKEN={{ .AWSSecurityToken }}
+SAML2AWS_PROFILE={{ .ProfileName }}
 `
 
 // Script will emit a bash script that will export environment variables
@@ -74,15 +82,16 @@ func Script(execFlags *flags.LoginExecFlags, shell string) error {
 		awsCreds,
 	}
 
-	err = buildTmpl(shell, data)
+	out, err := buildTmpl(shell, data)
 	if err != nil {
 		return errors.Wrap(err, "error generating template")
 	}
+	fmt.Println(out)
 
 	return nil
 }
 
-func buildTmpl(shell string, data interface{}) error {
+func buildTmpl(shell string, data interface{}) (string, error) {
 	t := template.New("envvar_script")
 
 	var err error
@@ -94,11 +103,18 @@ func buildTmpl(shell string, data interface{}) error {
 		t, err = t.Parse(powershellTmpl)
 	case "fish":
 		t, err = t.Parse(fishTmpl)
+	case "env":
+		t, err = t.Parse(envTmpl)
 	}
 
 	if err != nil {
-		return err
+		return "", err
 	}
 	// this is still written to stdout as per convention
-	return t.Execute(os.Stdout, data)
+	// return t.Execute(os.Stdout, data)
+
+	buf := &bytes.Buffer{}
+	err = t.Execute(buf, data)
+	return buf.String(), err
+
 }

--- a/cmd/saml2aws/commands/script_test.go
+++ b/cmd/saml2aws/commands/script_test.go
@@ -1,0 +1,108 @@
+package commands
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/versent/saml2aws/v2/pkg/awsconfig"
+)
+
+func TestBuildTmplBash(t *testing.T) {
+
+	data := struct {
+		ProfileName string
+		*awsconfig.AWSCredentials
+	}{
+		"test_profile",
+		&awsconfig.AWSCredentials{
+			AWSSecretKey:     "secret_key",
+			AWSAccessKey:     "access_key",
+			AWSSessionToken:  "session_token",
+			AWSSecurityToken: "security_token",
+			Expires:          time.Now(),
+		},
+	}
+
+	st, err := buildTmpl("bash", data)
+	assert.ErrorIs(t, err, nil)
+
+	expected := []string{
+		"export AWS_ACCESS_KEY_ID=\"access_key\"",
+		"export AWS_SECRET_ACCESS_KEY=\"secret_key\"",
+		"export AWS_SESSION_TOKEN=\"session_token\"",
+		"export AWS_SECURITY_TOKEN=\"security_token\"",
+		"export SAML2AWS_PROFILE=\"test_profile\"",
+	}
+
+	for _, test_string := range expected {
+		assert.Contains(t, st, test_string)
+	}
+
+}
+
+func TestBuildTmplFish(t *testing.T) {
+
+	data := struct {
+		ProfileName string
+		*awsconfig.AWSCredentials
+	}{
+		"test_profile",
+		&awsconfig.AWSCredentials{
+			AWSSecretKey:     "secret_key",
+			AWSAccessKey:     "access_key",
+			AWSSessionToken:  "session_token",
+			AWSSecurityToken: "security_token",
+			Expires:          time.Now(),
+		},
+	}
+
+	st, err := buildTmpl("fish", data)
+	assert.ErrorIs(t, err, nil)
+
+	expected := []string{
+		"set -gx AWS_ACCESS_KEY_ID access_key",
+		"set -gx AWS_SECRET_ACCESS_KEY secret_key",
+		"set -gx AWS_SESSION_TOKEN session_token",
+		"set -gx AWS_SECURITY_TOKEN security_token",
+		"set -gx SAML2AWS_PROFILE test_profile",
+	}
+
+	for _, test_string := range expected {
+		assert.Contains(t, st, test_string)
+	}
+
+}
+
+func TestBuildTmplEnv(t *testing.T) {
+
+	data := struct {
+		ProfileName string
+		*awsconfig.AWSCredentials
+	}{
+		"test_profile",
+		&awsconfig.AWSCredentials{
+			AWSSecretKey:     "secret_key",
+			AWSAccessKey:     "access_key",
+			AWSSessionToken:  "session_token",
+			AWSSecurityToken: "security_token",
+			Expires:          time.Now(),
+		},
+	}
+
+	st, err := buildTmpl("env", data)
+	assert.ErrorIs(t, err, nil)
+
+	expected := []string{
+		"AWS_ACCESS_KEY_ID=access_key",
+		"AWS_SECRET_ACCESS_KEY=secret_key",
+		"AWS_SESSION_TOKEN=session_token",
+		"AWS_SECURITY_TOKEN=security_token",
+		"SAML2AWS_PROFILE=test_profile",
+	}
+
+	for _, test_string := range expected {
+		assert.Contains(t, st, test_string)
+	}
+
+}

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -142,9 +142,9 @@ func main() {
 	cmdScript.Flag("credentials-file", "The file that will cache the credentials retrieved from AWS. When not specified, will use the default AWS credentials file location. (env: SAML2AWS_CREDENTIALS_FILE)").Envar("SAML2AWS_CREDENTIALS_FILE").StringVar(&commonFlags.CredentialsFile)
 	var shell string
 	cmdScript.
-		Flag("shell", "Type of shell environment. Options include: bash, powershell, fish").
+		Flag("shell", "Type of shell environment. Options include: bash, powershell, fish, env").
 		Default("bash").
-		EnumVar(&shell, "bash", "powershell", "fish")
+		EnumVar(&shell, "bash", "powershell", "fish", "env")
 
 	// Trigger the parsing of the command line inputs via kingpin
 	command := kingpin.MustParse(app.Parse(os.Args[1:]))


### PR DESCRIPTION
`script` is currently structured around shell compatible outputs only.
Some tools handle native env files, while looking similar they are
syntactically different.

Refactored the script code for testability.

Added some documentation.