### PR TITLE
Dont send captcha to stderr

### DIFF
--- a/pkg/provider/googleapps/googleapps.go
+++ b/pkg/provider/googleapps/googleapps.go
@@ -6,7 +6,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"log"
 	"net/http"
 	"net/url"
 	"os"
@@ -195,7 +194,7 @@ func (kc *Client) iTermCaptchaPrompt(captchaPictureURL string) (string, error) {
 }
 
 func simpleCaptchaPrompt(captchaPictureURL string) string {
-	log.Println("Open this link in a browser:\n", captchaPictureURL)
+	fmt.Println("Open this link in a browser:\n", captchaPictureURL)
 	return prompter.String("Captcha", "")
 }
 


### PR DESCRIPTION
Captcha prompts are being sent to stderr which is the default for `log.PrintLn`, use `fmt.PrintLn` instead so it's sent to stdout instead of stderr.