### PR TITLE
Only log the auth message when actually auth'ing

### DIFF
--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -83,8 +83,6 @@ func Login(loginFlags *flags.LoginExecFlags) error {
 		return errors.Wrap(err, "error validating login details")
 	}
 
-	log.Printf("Authenticating as %s ...", loginDetails.Username)
-
 	var samlAssertion string
 	if account.SAMLCache {
 		if cacheProvider.IsValid() {
@@ -94,7 +92,10 @@ func Login(loginFlags *flags.LoginExecFlags) error {
 			}
 		} else {
 			logger.Debug("Cache is invalid")
+			log.Printf("Authenticating as %s ...", loginDetails.Username)
 		}
+	} else {
+		log.Printf("Authenticating as %s ...", loginDetails.Username)
 	}
 
 	if samlAssertion == "" {


### PR DESCRIPTION
After the implementation of the samlcache in #634, the message
"Authenticating as ..." is printed systematically,
expected behaviour would be to print it only when `saml2aws` performs
the authentication.