### PR TITLE
Fix ISO-8601 format of expiration time in login.go

### DIFF
--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -370,7 +370,7 @@ func CredentialsToCredentialProcess(awsCreds *awsconfig.AWSCredentials) (string,
 		AccessKeyId:     awsCreds.AWSAccessKey,
 		SecretAccessKey: awsCreds.AWSSecretKey,
 		SessionToken:    awsCreds.AWSSessionToken,
-		Expiration:      awsCreds.Expires.Format("2006-01-02T15:04:05Z07:00"),
+		Expiration:      awsCreds.Expires.Format("2006-01-02T15:04:05-07:00"),
 	}
 
 	p, err := json.Marshal(cred_process)

--- a/cmd/saml2aws/commands/login_test.go
+++ b/cmd/saml2aws/commands/login_test.go
@@ -54,7 +54,7 @@ func TestCredentialsToCredentialProcess(t *testing.T) {
 		AWSSessionToken: "somesessiontoken",
 		Expires:         time.Date(2020, time.January, 20, 22, 50, 0, 0, time.UTC),
 	}
-	aws_json_expected_output := "{\"Version\":1,\"AccessKeyId\":\"someawsaccesskey\",\"SecretAccessKey\":\"somesecretkey\",\"SessionToken\":\"somesessiontoken\",\"Expiration\":\"2020-01-20T22:50:00\"}"
+	aws_json_expected_output := "{\"Version\":1,\"AccessKeyId\":\"someawsaccesskey\",\"SecretAccessKey\":\"somesecretkey\",\"SessionToken\":\"somesessiontoken\",\"Expiration\":\"2020-01-20T22:50:00+00:00\"}"
 
 	json, err := CredentialsToCredentialProcess(aws_creds)
 	assert.Empty(t, err)

--- a/cmd/saml2aws/commands/login_test.go
+++ b/cmd/saml2aws/commands/login_test.go
@@ -54,9 +54,9 @@ func TestCredentialsToCredentialProcess(t *testing.T) {
 		AWSSessionToken: "somesessiontoken",
 		Expires:         time.Date(2020, time.January, 20, 22, 50, 0, 0, time.UTC),
 	}
-	aws_json_expected_output := "{\"Version\":1,\"AccessKeyId\":\"someawsaccesskey\",\"SecretAccessKey\":\"somesecretkey\",\"SessionToken\":\"somesessiontoken\",\"Expiration\":\"2020-01-20T22:50:00Z\"}"
+	aws_json_expected_output := "{\"Version\":1,\"AccessKeyId\":\"someawsaccesskey\",\"SecretAccessKey\":\"somesecretkey\",\"SessionToken\":\"somesessiontoken\",\"Expiration\":\"2020-01-20T22:50:00\"}"
 
 	json, err := CredentialsToCredentialProcess(aws_creds)
 	assert.Empty(t, err)
-	assert.Equal(t, json, aws_json_expected_output)
+	assert.Equal(t, aws_json_expected_output, json)
 }


### PR DESCRIPTION
This was causing expiration times to be processed incorrectly.
Closes #646