### PR TITLE
Revert changes to time format in #651, use named format specifier

### DIFF
--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"log"
 	"os"
+	"time"
 
 	"github.com/aws/aws-sdk-go/aws"
 	"github.com/aws/aws-sdk-go/aws/session"
@@ -370,7 +371,7 @@ func CredentialsToCredentialProcess(awsCreds *awsconfig.AWSCredentials) (string,
 		AccessKeyId:     awsCreds.AWSAccessKey,
 		SecretAccessKey: awsCreds.AWSSecretKey,
 		SessionToken:    awsCreds.AWSSessionToken,
-		Expiration:      awsCreds.Expires.Format("2006-01-02T15:04:05-07:00"),
+		Expiration:      awsCreds.Expires.Format(time.RFC3339),
 	}
 
 	p, err := json.Marshal(cred_process)

--- a/cmd/saml2aws/commands/login_test.go
+++ b/cmd/saml2aws/commands/login_test.go
@@ -54,7 +54,7 @@ func TestCredentialsToCredentialProcess(t *testing.T) {
 		AWSSessionToken: "somesessiontoken",
 		Expires:         time.Date(2020, time.January, 20, 22, 50, 0, 0, time.UTC),
 	}
-	aws_json_expected_output := "{\"Version\":1,\"AccessKeyId\":\"someawsaccesskey\",\"SecretAccessKey\":\"somesecretkey\",\"SessionToken\":\"somesessiontoken\",\"Expiration\":\"2020-01-20T22:50:00+00:00\"}"
+	aws_json_expected_output := "{\"Version\":1,\"AccessKeyId\":\"someawsaccesskey\",\"SecretAccessKey\":\"somesecretkey\",\"SessionToken\":\"somesessiontoken\",\"Expiration\":\"2020-01-20T22:50:00Z\"}"
 
 	json, err := CredentialsToCredentialProcess(aws_creds)
 	assert.Empty(t, err)


### PR DESCRIPTION
Turns out the root cause was not what my changes addressed. My changes didn't break anything, but for the sake of clarity, I'm mostly reverting them. The only remaing changes
after this commit are to use a named format, rather than a confusing format string, and keeping the the correct order of arguments in the unit test.

This change correctly fixes #646.