### PR TITLE
build releases with U2F support on linux

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -7,6 +7,7 @@ builds:
   flags:
     - -trimpath
     - -v
+    - -tags={{ if (eq .Env.GOOS "linux") }}hidraw{{ end }}
   ldflags:
     - -s -w -X main.Version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
   goos:


### PR DESCRIPTION
## Background

U2F device enumeration for JumpCloud is via [marshallbrekka/go-u2fhost](https://github.com/marshallbrekka/go-u2fhost) which requires `-tags=hidraw` to be built with raw HID support otherwise it fails to find the U2F device.