### PR TITLE
Make providers compatible with non-AWS targets

### DIFF
--- a/README.md
+++ b/README.md
@@ -543,6 +543,7 @@ Use following parameters in `~/.saml2aws` file:
 - `http_attempts_count` - configures the number of attempts to send http requests in order to authorise with saml provider. Defaults to 1
 - `http_retry_delay` - configures the duration (in seconds) of timeout between attempts to send http requests to saml provider. Defaults to 1
 - `region` - configures which region endpoints to use, See [Audience](https://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_providers_create_saml_assertions.html#saml_audience-restriction) and [partition](https://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html#arns-syntax)
+- `target_url` - look for a target endpoint other than signin.aws.amazon.com/saml. The Okta, Pingfed, Pingone and Shibboleth ECP providers need to either explicitly send or look for this URL in a response in order to obtain or identify an appropriate authentication response. This can be overridden here if you wish to authenticate for something other than AWS.
 
 Example: typical configuration with such parameters would look like follows:
 ```

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -50,6 +50,7 @@ type IDPAccount struct {
 	CredentialsFile      string `ini:"credentials_file"`
 	SAMLCache            bool   `ini:"saml_cache"`
 	SAMLCacheFile        string `ini:"saml_cache_file"`
+	TargetURL            string `ini:"target_url"`
 }
 
 func (ia IDPAccount) String() string {

--- a/pkg/provider/pingfed/pingfed.go
+++ b/pkg/provider/pingfed/pingfed.go
@@ -75,7 +75,7 @@ func (ac *Client) follow(ctx context.Context, req *http.Request) (string, error)
 
 	var handler func(context.Context, *goquery.Document) (context.Context, *http.Request, error)
 
-	if docIsFormRedirectToAWS(doc) {
+	if docIsFormRedirectToTarget(doc, ac.idpAccount.TargetURL) {
 		logger.WithField("type", "saml-response-to-aws").Debug("doc detect")
 		if samlResponse, ok := extractSAMLResponse(doc); ok {
 			decodedSamlResponse, err := base64.StdEncoding.DecodeString(samlResponse)
@@ -256,8 +256,12 @@ func docIsFormResume(doc *goquery.Document) bool {
 	return doc.Find("input[name=\"RelayState\"]").Size() == 1
 }
 
-func docIsFormRedirectToAWS(doc *goquery.Document) bool {
-	return doc.Find("form[action=\"https://signin.aws.amazon.com/saml\"]").Size() == 1
+func docIsFormRedirectToTarget(doc *goquery.Document, target string) bool {
+	if target == "" {
+		target = "https://signin.aws.amazon.com/saml"
+	}
+	urlForm := fmt.Sprintf("form[action=\"%s\"]", target)
+	return doc.Find(urlForm).Size() == 1
 }
 
 func extractSAMLResponse(doc *goquery.Document) (v string, ok bool) {

--- a/pkg/provider/pingone/pingone.go
+++ b/pkg/provider/pingone/pingone.go
@@ -87,7 +87,7 @@ func (ac *Client) follow(ctx context.Context, req *http.Request) (string, error)
 
 	var handler func(context.Context, *goquery.Document, *http.Response) (context.Context, *http.Request, error)
 
-	if docIsFormRedirectToAWS(doc) {
+	if docIsFormRedirectToTarget(doc, ac.idpAccount.TargetURL) {
 		logger.WithField("type", "saml-response-to-aws").Debug("doc detect")
 		if samlResponse, ok := extractSAMLResponse(doc); ok {
 			decodedSamlResponse, err := base64.StdEncoding.DecodeString(samlResponse)
@@ -318,8 +318,12 @@ func docIsFormResume(doc *goquery.Document) bool {
 	return doc.Find("input[name=\"RelayState\"]").Size() == 1 || doc.Find("input[name=\"Resume\"]").Size() == 1
 }
 
-func docIsFormRedirectToAWS(doc *goquery.Document) bool {
-	return doc.Find("form[action=\"https://signin.aws.amazon.com/saml\"]").Size() == 1
+func docIsFormRedirectToTarget(doc *goquery.Document, target string) bool {
+	if target == "" {
+		target = "https://signin.aws.amazon.com/saml"
+	}
+	urlForm := fmt.Sprintf("form[action=\"%s\"]", target)
+	return doc.Find(urlForm).Size() == 1
 }
 
 func docIsFormSelectDevice(doc *goquery.Document) bool {

--- a/pkg/provider/shibbolethecp/shibbolethecp.go
+++ b/pkg/provider/shibbolethecp/shibbolethecp.go
@@ -85,7 +85,7 @@ func New(idpAccount *cfg.IDPAccount) (*Client, error) {
 // Authenticate authenticates to a Shibboleth ECP profile and return the data from the body of the SAML assertion.
 func (c *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error) {
 	// Step 1: Request resource from IdP, indicate we are ECP capable
-	ar, err := authnRequest(c.idpAccount.AmazonWebservicesURN)
+	ar, err := authnRequest(c.idpAccount.AmazonWebservicesURN, c.idpAccount.TargetURL)
 	if err != nil {
 		return "", err
 	}
@@ -140,16 +140,19 @@ func (c *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error) 
 }
 
 // authnRequest creates a SOAP-XML AuthnRequest from EntityID
-func authnRequest(entityID string) (io.Reader, error) {
+func authnRequest(entityID string, target string) (io.Reader, error) {
 	// create authnRequest from template, due to fragility in xml/encoding when handling namespaces
 	t, err := template.New("authnRequest").Parse(authnRequestTpl)
 	if err != nil {
 		return nil, errors.Wrap(err, "Error parsing authnRequest template")
 	}
+	if target == "" {
+		target = "https://signin.aws.amazon.com/saml"
+	}
 	ard := authnRequestData{
 		ID:                          uuid.New().String(),
 		IssueInstant:                time.Now().Format(time.RFC3339),
-		AssertionConsumerServiceURL: "https://signin.aws.amazon.com/saml",
+		AssertionConsumerServiceURL: target,
 		EntityID:                    entityID,
 	}
 

--- a/pkg/provider/shibbolethecp/shibbolethecp_test.go
+++ b/pkg/provider/shibbolethecp/shibbolethecp_test.go
@@ -14,7 +14,7 @@ import (
 func TestAuthnRequest(t *testing.T) {
 	input := "foo"
 
-	result, err := authnRequest(input)
+	result, err := authnRequest(input, "")
 	assert.NoError(t, err)
 
 	doc := etree.NewDocument()


### PR DESCRIPTION
Nothing about the SAML response provided by the identity providers is tied
to Amazon other than the redirect URL and the provider ID. The provider ID
can be overridden with the aws_urn config parameter, but for some providers
the redirect URL is hardcoded in order to detect a page containing the SAML
response. This patch adds a target_url configuration parameter to allow the
hardcoded values to be overridden, making it possible to use the providers
for non-AWS purposes.