### PR TITLE
[README Change] Add Apostrophe Blocks Around Provided Linux Installation wget Target URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ While brew is available for Linux you can also run the following without using a
 
 ```
 $ CURRENT_VERSION=$(curl -Ls https://api.github.com/repos/Versent/saml2aws/releases/latest | grep 'tag_name' | cut -d'v' -f2 | cut -d'"' -f1)
-$ wget -c https://github.com/Versent/saml2aws/releases/download/v${CURRENT_VERSION}/saml2aws_${CURRENT_VERSION}_linux_amd64.tar.gz -O - | tar -xzv -C ~/.local/bin
+$ wget -c 'https://github.com/Versent/saml2aws/releases/download/v${CURRENT_VERSION}/saml2aws_${CURRENT_VERSION}_linux_amd64.tar.gz -O - | tar -xzv -C ~/.local/bin'
 $ chmod u+x ~/.local/bin/saml2aws
 $ hash -r
 $ saml2aws --version


### PR DESCRIPTION
Some terminal shells (ZSH specifically) auto correct `wget -c https://github.com/Versent/saml2aws/releases/download/v${CURRENT_VERSION}/saml2aws_${CURRENT_VERSION}_linux_amd64.tar.gz -O - | tar -xzv -C ~/.local/bin` to `wget -c https://github.com/Versent/saml2aws/releases/download/v$\{CURRENT_VERSION\}/saml2aws_$\{CURRENT_VERSION\}_linux_amd64.tar.gz -O - | tar -xzv -C ~/.local/bin` when there is no apostrophe literal around the target. This results in the real download URL never actually being reached and a 404 error.

Surrounding the wget target in apostrophes (as done in this pull request) prevents this auto correction resulting in a better user experience.


---

(btw) Thanks for this cool tool! Federated login is awesome.