### PR TITLE
Feature/handle wrong password with GSuite

### DIFF
--- a/pkg/provider/googleapps/googleapps.go
+++ b/pkg/provider/googleapps/googleapps.go
@@ -157,6 +157,9 @@ func (kc *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 
 	samlAssertion := mustFindInputByName(responseDoc, "SAMLResponse")
 	if samlAssertion == "" {
+		if responseDoc.Selection.Find("#passwordError").Text() != "" {
+			return "", errors.New("Password error")
+		}
 		return "", errors.New("page is missing saml assertion")
 	}
 

--- a/pkg/provider/googleapps/googleapps_test.go
+++ b/pkg/provider/googleapps/googleapps_test.go
@@ -107,3 +107,13 @@ func TestExtractDataAttributes(t *testing.T) {
 
 	require.Equal(t, "https://apis.google.com/js/base.js", dataAttrs["data-gapi-url"])
 }
+
+func TestWrongPassword(t *testing.T) {
+	passwordErrorId := "passwordError"
+	html := `<html><body><span class="Qx8Abe" id="` + passwordErrorId + `">Wrong password. Try again or click Forgot password to reset it.</span></body></html>`
+
+	doc, err := goquery.NewDocumentFromReader(strings.NewReader(html))
+	require.Nil(t, err)
+	txt := doc.Selection.Find("#" + passwordErrorId).Text()
+	require.NotEqual(t, "", txt)
+}


### PR DESCRIPTION
Closes #687 

Before this PR, when the user inputs wrong password, the raised error was

> `error authenticating to IdP: page is missing saml assertion`

After this PR, when the user inputs wrong password, the raised error is

> `error authenticating to IdP: Password error`

@wolfeidau please let me know if there's anything else needed to merge this PR