### PR TITLE
Make Browser a valid option for provider and idp-provider flags

### DIFF
--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -63,13 +63,13 @@ func main() {
 	verbose := app.Flag("verbose", "Enable verbose logging").Bool()
 	quiet := app.Flag("quiet", "silences logs").Bool()
 
-	provider := app.Flag("provider", "This flag is obsolete. See: https://github.com/Versent/saml2aws#configuring-idp-accounts").Short('i').Enum("Akamai", "AzureAD", "ADFS", "ADFS2", "Ping", "JumpCloud", "Okta", "OneLogin", "PSU", "KeyCloak")
+	provider := app.Flag("provider", "This flag is obsolete. See: https://github.com/Versent/saml2aws#configuring-idp-accounts").Short('i').Enum("Akamai", "AzureAD", "ADFS", "ADFS2", "Browser", "Ping", "JumpCloud", "Okta", "OneLogin", "PSU", "KeyCloak")
 
 	// Common (to all commands) settings
 	commonFlags := new(flags.CommonFlags)
 	app.Flag("config", "Path/filename of saml2aws config file (env: SAML2AWS_CONFIGFILE)").Envar("SAML2AWS_CONFIGFILE").StringVar(&commonFlags.ConfigFile)
 	app.Flag("idp-account", "The name of the configured IDP account. (env: SAML2AWS_IDP_ACCOUNT)").Envar("SAML2AWS_IDP_ACCOUNT").Short('a').Default("default").StringVar(&commonFlags.IdpAccount)
-	app.Flag("idp-provider", "The configured IDP provider. (env: SAML2AWS_IDP_PROVIDER)").Envar("SAML2AWS_IDP_PROVIDER").EnumVar(&commonFlags.IdpProvider, "Akamai", "AzureAD", "ADFS", "ADFS2", "GoogleApps", "Ping", "JumpCloud", "Okta", "OneLogin", "PSU", "KeyCloak", "F5APM", "Shibboleth", "ShibbolethECP", "NetIQ", "Auth0")
+	app.Flag("idp-provider", "The configured IDP provider. (env: SAML2AWS_IDP_PROVIDER)").Envar("SAML2AWS_IDP_PROVIDER").EnumVar(&commonFlags.IdpProvider, "Akamai", "AzureAD", "ADFS", "ADFS2", "Browser", "GoogleApps", "Ping", "JumpCloud", "Okta", "OneLogin", "PSU", "KeyCloak", "F5APM", "Shibboleth", "ShibbolethECP", "NetIQ", "Auth0")
 	app.Flag("mfa", "The name of the mfa. (env: SAML2AWS_MFA)").Envar("SAML2AWS_MFA").StringVar(&commonFlags.MFA)
 	app.Flag("skip-verify", "Skip verification of server certificate. (env: SAML2AWS_SKIP_VERIFY)").Envar("SAML2AWS_SKIP_VERIFY").Short('s').BoolVar(&commonFlags.SkipVerify)
 	app.Flag("url", "The URL of the SAML IDP server used to login. (env: SAML2AWS_URL)").Envar("SAML2AWS_URL").StringVar(&commonFlags.URL)

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -122,8 +122,10 @@ func (ia *IDPAccount) Validate() error {
 		return errors.New("Provider empty in idp account")
 	}
 
-	if ia.MFA == "" {
-		return errors.New("MFA empty in idp account")
+	if ia.Provider != "Browser" {
+		if ia.MFA == "" {
+			return errors.New("MFA empty in idp account")
+		}
 	}
 
 	if ia.Profile == "" {


### PR DESCRIPTION
Make Browser a valid option for `provider` and `idp-provider` flags

This change fixes the error that it is **not** possible to configure a **Browser** `idp-provider` based profile without prompt.

```
~ via ❄️  impure (shell) took 9s
❯ saml2aws configure -a test --idp-provider Browser -r eu-central-1 --url 'https://xxx' --role 'arn:aws:iam::xxxxxxxxxxxx:role/xxx/xxx' --skip-promptsaml2aws: error: enum value must be one of Akamai,AzureAD,ADFS,ADFS2,GoogleApps,Ping,JumpCloud,Okta,OneLogin,PSU,KeyCloak,F5APM,Shibboleth,ShibbolethECP,NetIQ,Auth0, got 'Browser', try --help
```

P.s I'm not 100% sure if the solution to bypass the  **MFA** check is okish :thinking: 

P.s.s Whan #693 is merged I'm going to rebase this branch :smile: 
