### PR TITLE
Allow 401/SPNEGO response and handle refresh for PingFed

### DIFF
--- a/pkg/provider/http.go
+++ b/pkg/provider/http.go
@@ -168,6 +168,18 @@ func SuccessOrRedirectResponseValidator(req *http.Request, resp *http.Response) 
 	return errors.Errorf("request for url: %s failed status: %s", req.URL.String(), resp.Status)
 }
 
+// SuccessOrRedirectOrUnauthorizedResponseValidator also allows 401
+func SuccessOrRedirectOrUnauthorizedResponseValidator(req *http.Request, resp *http.Response) error {
+
+	validatorResponse := SuccessOrRedirectResponseValidator(req, resp)
+
+	if validatorResponse == nil || resp.StatusCode == 401 {
+		return nil
+	}
+
+	return validatorResponse
+}
+
 func (hc *HTTPClient) logHTTPRequest(req *http.Request) {
 
 	if dump.ContentEnable() {

--- a/pkg/provider/pingone/pingone.go
+++ b/pkg/provider/pingone/pingone.go
@@ -30,18 +30,6 @@ type Client struct {
 	idpAccount *cfg.IDPAccount
 }
 
-// SuccessOrRedirectOrUnauthorizedResponseValidator also allows 401
-func SuccessOrRedirectOrUnauthorizedResponseValidator(req *http.Request, resp *http.Response) error {
-
-	validatorResponse := provider.SuccessOrRedirectResponseValidator(req, resp)
-
-	if validatorResponse == nil || resp.StatusCode == 401 {
-		return nil
-	}
-
-	return validatorResponse
-}
-
 // New create a new PingOne client
 func New(idpAccount *cfg.IDPAccount) (*Client, error) {
 
@@ -54,7 +42,7 @@ func New(idpAccount *cfg.IDPAccount) (*Client, error) {
 
 	// assign a response validator to ensure all responses are either success or a redirect
 	// this is to avoid have explicit checks for every single response
-	client.CheckResponseStatus = SuccessOrRedirectOrUnauthorizedResponseValidator
+	client.CheckResponseStatus = provider.SuccessOrRedirectOrUnauthorizedResponseValidator
 
 	return &Client{
 		client:     client,


### PR DESCRIPTION
This is the same change as in PR #574 for PingOne, but applied to PingFed for the same reason involving corporate VPN and a 401 for SPNEGO authentication.