### PR TITLE
[Azure AD] Failed due to expired password

### DIFF
--- a/pkg/provider/aad/aad.go
+++ b/pkg/provider/aad/aad.go
@@ -1132,6 +1132,10 @@ func (ac *Client) processMfaAuth(mfaResp mfaResponse, loginPasswordResp password
 			return res, errors.Wrap(err, "ProcessAuth response unmarshal error")
 		}
 
+		if processAuthResp.URLPost == "/common/SSPR/End" {
+			return res, errors.Wrap(err, "please reset your AzureAD password")
+		}
+
 		res, err = ac.kmsiRequest(
 			res.Request.URL.Scheme, res.Request.URL.Host, processAuthResp.URLPost, processAuthResp.SFT, processAuthResp.SCtx)
 		if err != nil {


### PR DESCRIPTION
Just to validate if a Password reset is required, try for a few hour debugging, cuz the tool didn't tell me what was wrong, just throw `error authenticating to IdP: unable to locate IDP oidc form submit URL` and it was confusing