### PR TITLE
Allow hash in URL

### DIFF
--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -196,7 +196,7 @@ func (cm *ConfigManager) SaveIDPAccount(idpAccountName string, account *IDPAccou
 // LoadIDPAccount load the idp account and default to an empty one if it doesn't exist
 func (cm *ConfigManager) LoadIDPAccount(idpAccountName string) (*IDPAccount, error) {
 
-	cfg, err := ini.LoadSources(ini.LoadOptions{Loose: true}, cm.configPath)
+	cfg, err := ini.LoadSources(ini.LoadOptions{Loose: true, SpaceBeforeInlineComment: true}, cm.configPath)
 	if err != nil {
 		return nil, errors.Wrap(err, "Unable to load configuration file")
 	}

--- a/pkg/cfg/cfg_test.go
+++ b/pkg/cfg/cfg_test.go
@@ -28,7 +28,7 @@ func TestNewConfigManagerLoad(t *testing.T) {
 	require.Nil(t, err)
 	require.Equal(t, &IDPAccount{
 		Name:                 "test123",
-		URL:                  "https://id.whatever.com",
+		URL:                  "https://id.whatever.com/#/hash",
 		Username:             "abc@whatever.com",
 		Provider:             "keycloak",
 		MFA:                  "sms",

--- a/pkg/cfg/example/saml2aws.ini
+++ b/pkg/cfg/example/saml2aws.ini
@@ -7,7 +7,6 @@ mfa      = totp
 username    = abc@whatever.com
 provider    = keycloak
 mfa         = sms
-url         = https://id.whatever.com
+url         = https://id.whatever.com/#/hash
 skip_verify = false
 timeout     = 0
-


### PR DESCRIPTION
Ini parser considers hash as an inline comment and removes it. Instead
we configure the parser to only consider hash an inline comment when it
is preceded by a space.