### PR TITLE
Adding a new Oath mfa check for ADFS

### DIFF
--- a/pkg/provider/adfs/adfs.go
+++ b/pkg/provider/adfs/adfs.go
@@ -200,6 +200,9 @@ func checkResponse(doc *goquery.Document) (AuthResponseType, string, error) {
 			samlAssertion = val
 			responseType = SAML_RESPONSE
 		}
+		if name == "OathCode" {
+			responseType = MFA_PROMPT
+		}
 		if name == "AuthMethod" {
 			val, _ := s.Attr("value")
 			switch val {
@@ -256,6 +259,8 @@ func updateOTPFormData(otpForm url.Values, s *goquery.Selection, token string) {
 	} else if strings.Contains(lname, "verificationcode") {
 		otpForm.Add(name, token)
 	} else if strings.Contains(lname, "challengequestionanswer") {
+		otpForm.Add(name, token)
+	} else if strings.Contains(lname, "oathcode") {
 		otpForm.Add(name, token)
 	} else {
 		updatePassthroughFormData(otpForm, s)


### PR DESCRIPTION
Our setup is falling through the cracks of the current ADFS parsing
strategy. Our field corresponding to the TOTP request is called Oath.

This change adds it to the list of fields it's already parsing.