### PR TITLE
Fix: Removing quotes during `saml2aws`

### DIFF
--- a/cmd/saml2aws/commands/script.go
+++ b/cmd/saml2aws/commands/script.go
@@ -12,12 +12,12 @@ import (
 	"github.com/versent/saml2aws/v2/pkg/flags"
 )
 
-const bashTmpl = `export AWS_ACCESS_KEY_ID="{{ .AWSAccessKey }}"
-export AWS_SECRET_ACCESS_KEY="{{ .AWSSecretKey }}"
-export AWS_SESSION_TOKEN="{{ .AWSSessionToken }}"
-export AWS_SECURITY_TOKEN="{{ .AWSSecurityToken }}"
-export SAML2AWS_PROFILE="{{ .ProfileName }}"
-export AWS_CREDENTIAL_EXPIRATION="{{ .Expires.Format "2006-01-02T15:04:05Z07:00" }}"
+const bashTmpl = `export AWS_ACCESS_KEY_ID={{ .AWSAccessKey }}
+export AWS_SECRET_ACCESS_KEY={{ .AWSSecretKey }}
+export AWS_SESSION_TOKEN={{ .AWSSessionToken }}
+export AWS_SECURITY_TOKEN={{ .AWSSecurityToken }}
+export SAML2AWS_PROFILE={{ .ProfileName }}
+export AWS_CREDENTIAL_EXPIRATION={{ .Expires.Format "2006-01-02T15:04:05Z07:00" }}
 `
 
 const fishTmpl = `set -gx AWS_ACCESS_KEY_ID {{ .AWSAccessKey }}

--- a/cmd/saml2aws/commands/script_test.go
+++ b/cmd/saml2aws/commands/script_test.go
@@ -28,11 +28,11 @@ func TestBuildTmplBash(t *testing.T) {
 	assert.ErrorIs(t, err, nil)
 
 	expected := []string{
-		"export AWS_ACCESS_KEY_ID=\"access_key\"",
-		"export AWS_SECRET_ACCESS_KEY=\"secret_key\"",
-		"export AWS_SESSION_TOKEN=\"session_token\"",
-		"export AWS_SECURITY_TOKEN=\"security_token\"",
-		"export SAML2AWS_PROFILE=\"test_profile\"",
+		"export AWS_ACCESS_KEY_ID=access_key",
+		"export AWS_SECRET_ACCESS_KEY=secret_key",
+		"export AWS_SESSION_TOKEN=session_token",
+		"export AWS_SECURITY_TOKEN=security_token",
+		"export SAML2AWS_PROFILE=test_profile",
 	}
 
 	for _, test_string := range expected {


### PR DESCRIPTION
Fixes #447.

The quotes are interpreted as literals by `export` and needed to be removed.