### PR TITLE
Fix nil dereference when JumpCloud DUO is denied or timed out

### DIFF
--- a/pkg/provider/jumpcloud/jumpcloud.go
+++ b/pkg/provider/jumpcloud/jumpcloud.go
@@ -175,6 +175,10 @@ func (jc *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 		}
 	}
 
+	if res == nil {
+		return samlAssertion, fmt.Errorf("mfa timed out or denied")
+	}
+
 	// Check if our auth was successful
 	if res.StatusCode == 200 {
 		// Grab the body from the response that has the redirect in it.


### PR DESCRIPTION
Responding to https://github.com/Versent/saml2aws/issues/757

Response body will be closed in case of 401 by the time we attempt to
compare it with 200 in case if deny or time out. Not sure how it slipped
in, given I used existing code. Perhaps never worked or I made a silly
change somewhere, e.g. closing response body handler.

It works correctly now.

![image](https://user-images.githubusercontent.com/1124779/148132291-b2ee1b2b-3b85-48f4-86c1-76486c239c03.png)



