### PR TITLE
helper/linuxkeyring: use configured pass directory

### DIFF
--- a/helper/linuxkeyring/linuxkeyring.go
+++ b/helper/linuxkeyring/linuxkeyring.go
@@ -2,6 +2,7 @@ package linuxkeyring
 
 import (
 	"encoding/json"
+	"os"
 
 	"github.com/99designs/keyring"
 	"github.com/sirupsen/logrus"
@@ -23,6 +24,7 @@ func NewKeyringHelper() (*KeyringHelper, error) {
 		},
 		LibSecretCollectionName: "login",
 		PassPrefix:              "saml2aws",
+		PassDir:                 os.Getenv("PASSWORD_STORE_DIR"),
 	})
 
 	if err != nil {


### PR DESCRIPTION
When the keyring package is configured and PassDir is empty it will
default to ~/.password-store/.

See https://github.com/99designs/keyring/blob/master/pass.go#L26

Closes #440