### PR TITLE
Fix infinite loop with Okta push

### DIFF
--- a/pkg/provider/okta/okta_test.go
+++ b/pkg/provider/okta/okta_test.go
@@ -1,6 +1,7 @@
 package okta
 
 import (
+	"crypto/tls"
 	"errors"
 	"fmt"
 	"net/http"
@@ -11,6 +12,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/versent/saml2aws/v2/pkg/cfg"
 	"github.com/versent/saml2aws/v2/pkg/creds"
+	"github.com/versent/saml2aws/v2/pkg/provider"
 )
 
 type stateTokenTests struct {
@@ -59,6 +61,81 @@ func TestGetStateTokenFromOktaPageBody(t *testing.T) {
 
 		})
 	}
+}
+
+func TestGetMfaChallengeContext(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte("OK"))
+	}))
+	defer ts.Close()
+
+	t.Run("Verify link without query parameters", func(t *testing.T) {
+		oc, loginDetails := setupTestClient(t, ts, "PUSH")
+
+		err := oc.setDeviceTokenCookie(loginDetails)
+		assert.Nil(t, err)
+
+		context, err := getMfaChallengeContext(oc, 0, fmt.Sprintf(`{
+			"stateToken": "TOKEN",
+			"_embedded": {
+				"factors": [
+					{
+						"id": "PUSH",
+						"provider": "OKTA",
+						"factorType": "PUSH",
+						"_links": {
+							"verify": { "href": "%s/verify" }
+						}
+					}
+				]
+			}
+		}`, ts.URL))
+		assert.Nil(t, err)
+
+		assert.Equal(t, ts.URL+"/verify?rememberDevice=true", context.oktaVerify)
+	})
+
+	t.Run("Verify link with query parameters", func(t *testing.T) {
+		oc, loginDetails := setupTestClient(t, ts, "PUSH")
+
+		err := oc.setDeviceTokenCookie(loginDetails)
+		assert.Nil(t, err)
+
+		context, err := getMfaChallengeContext(oc, 0, fmt.Sprintf(`{
+			"stateToken": "TOKEN",
+			"_embedded": {
+				"factors": [
+					{
+						"id": "PUSH",
+						"provider": "OKTA",
+						"factorType": "PUSH",
+						"_links": {
+							"verify": { "href": "%s/verify?p=1" }
+						}
+					}
+				]
+			}
+		}`, ts.URL))
+		assert.Nil(t, err)
+
+		assert.Equal(t, ts.URL+"/verify?p=1&rememberDevice=true", context.oktaVerify)
+	})
+}
+
+func setupTestClient(t *testing.T, ts *httptest.Server, mfa string) (*Client, *creds.LoginDetails) {
+	testTransport := http.DefaultTransport.(*http.Transport).Clone()
+	testTransport.TLSClientConfig = &tls.Config{InsecureSkipVerify: true}
+	opts := &provider.HTTPClientOptions{IsWithRetries: false}
+	client, _ := provider.NewHTTPClient(testTransport, opts)
+	ac := &Client{
+		client:          client,
+		targetURL:       ts.URL,
+		mfa:             mfa,
+		disableSessions: false,
+		rememberDevice:  true,
+	}
+	loginDetails := &creds.LoginDetails{URL: ts.URL, Username: "user@example.com", Password: "test123"}
+	return ac, loginDetails
 }
 
 func TestSetDeviceTokenCookie(t *testing.T) {
@@ -184,7 +261,11 @@ func TestOktaParseMfaIdentifer(t *testing.T) {
 }
 
 func TestGetStateToken(t *testing.T) {
+
+	persistedCookie := &http.Cookie{Name: "TestCookie", Value: "test"}
 	svr := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		assert.Contains(t, r.Cookies(), persistedCookie)
+
 		expected := "var stateToken = \"token1\";"
 		_, err := w.Write([]byte(expected))
 		assert.Nil(t, err)
@@ -205,7 +286,10 @@ func TestGetStateToken(t *testing.T) {
 	oc, err := New(idpAccount)
 	assert.Nil(t, err)
 
-	stateToken, err := oc.getStateToken(loginDetails)
+	req, _ := http.NewRequest("GET", "/", nil)
+	req.AddCookie(persistedCookie)
+
+	stateToken, err := oc.getStateToken(req, loginDetails)
 	assert.Nil(t, err)
 	assert.Equal(t, "token1", stateToken)
 }


### PR DESCRIPTION
This PR fixes Okta infinite loop with MFA push, raised in issue #714.

I have tested this on my machine, and have been using it for several months now.

Please note that I'm a complete Go newbie, so any suggestions and improvements are welcome.