### PR TITLE
Add the option to set a persistent storage for the browser provider

### DIFF
--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -224,7 +224,7 @@ func resolveLoginDetails(account *cfg.IDPAccount, loginFlags *flags.LoginExecFla
 		return loginDetails, nil
 	}
 
-	if account.Provider != "Shell" {
+	if account.Provider != "Shell" && account.Provider != "Browser" {
 		err = saml2aws.PromptForLoginDetails(loginDetails, account.Provider)
 		if err != nil {
 			return nil, errors.Wrap(err, "Error occurred accepting input.")

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -97,6 +97,7 @@ func main() {
 	cmdConfigure.Flag("cache-file", "The location of the SAML cache file (env: SAML2AWS_SAML_CACHE_FILE)").Envar("SAML2AWS_SAML_CACHE_FILE").StringVar(&commonFlags.SAMLCacheFile)
 	cmdConfigure.Flag("disable-sessions", "Do not use Okta sessions. Uses Okta sessions by default. (env: SAML2AWS_OKTA_DISABLE_SESSIONS)").Envar("SAML2AWS_OKTA_DISABLE_SESSIONS").BoolVar(&commonFlags.DisableSessions)
 	cmdConfigure.Flag("disable-remember-device", "Do not remember Okta MFA device. Remembers MFA device by default. (env: SAML2AWS_OKTA_DISABLE_REMEMBER_DEVICE)").Envar("SAML2AWS_OKTA_DISABLE_REMEMBER_DEVICE").BoolVar(&commonFlags.DisableRememberDevice)
+	cmdConfigure.Flag("persistent-data-dir", "Persistent storage for the browser provider. Allows saving passwords and sessions between uses. (env: SAML2AWS_PERSISTENT_DATA_DIR)").Envar("SAML2AWS_PERSISTENT_DATA_DIR").StringVar(&commonFlags.PersistentDataDir)
 	configFlags := commonFlags
 
 	// `login` command and settings

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -55,6 +55,7 @@ type IDPAccount struct {
 	DisableRememberDevice bool   `ini:"disable_remember_device"` // used by Okta
 	DisableSessions       bool   `ini:"disable_sessions"`        // used by Okta
 	Prompter              string `ini:"prompter"`
+	PersistentDataDir     string `ini:"persistent_data_dir"` // Used by browser
 }
 
 func (ia IDPAccount) String() string {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -33,6 +33,7 @@ type CommonFlags struct {
 	DisableRememberDevice bool
 	DisableSessions       bool
 	Prompter              string
+	PersistentDataDir     string
 }
 
 // LoginExecFlags flags for the Login / Exec commands
@@ -117,6 +118,9 @@ func ApplyFlagOverrides(commonFlags *CommonFlags, account *cfg.IDPAccount) {
 	}
 	if commonFlags.Prompter != "" {
 		account.Prompter = commonFlags.Prompter
+	}
+	if commonFlags.PersistentDataDir != "" {
+		account.PersistentDataDir = commonFlags.PersistentDataDir
 	}
 
 	// select the prompter


### PR DESCRIPTION
This enables using an IDP that has a browser session and providing credentials only once.

Can help #729

Example usage:
`saml2aws configure --url https://account.activedirectory.windowsazure.com/applications/signin/<app_id>?tenantId=<tenantId> --persistent-data-dir ~/.persistent_data_dir -a browser --idp-provider Browser --skip-prompt`