### PR TITLE
Add Entropy to mfaBegin Response & struct

### DIFF
--- a/pkg/provider/aad/aad.go
+++ b/pkg/provider/aad/aad.go
@@ -486,6 +486,7 @@ type mfaResponse struct {
 	SessionID     string      `json:"SessionId"`
 	CorrelationID string      `json:"CorrelationId"`
 	Timestamp     time.Time   `json:"Timestamp"`
+	Entropy       string      `json:"Entropy"`
 }
 
 // Autogenerate ProcessAuth response
@@ -977,7 +978,7 @@ func (ac *Client) getMfaFlowToken(mfas []userProof, loginPasswordResp passwordLo
 			mfaReq.AdditionalAuthData = verifyCode
 		}
 		if mfaReq.AuthMethodID == "PhoneAppNotification" && i == 0 {
-			log.Println("Phone approval required.")
+			log.Println("Phone approval required. Entropy is: " + mfaResp.Entropy)
 		}
 		mfaReqJson, err := json.Marshal(mfaReq)
 		if err != nil {


### PR DESCRIPTION
Entropy is not handled in the MFA Response. Adding it to the Print message so we can see it. 

This is the messages requested by the Microsoft Authenticator now asking you to input a 2-digit number when you use the `mfaReq.AuthMethodID == "PhoneAppNotification"`