### PR TITLE
Bump Golang to 1.18 for Appveyor

### DIFF
--- a/.appveyor/appveyor.yml
+++ b/.appveyor/appveyor.yml
@@ -6,7 +6,8 @@ environment:
     secure: 3kWTz99Qj+ipyaR73CxcJeGRRbmk84MF2ERDu6MyY10cjHAi6s3AVZ2Ccoa+Ioyt
   appName: saml2aws
 install:
-- set PATH=C:\msys64\mingw64\bin;%PATH%
+- set PATH=C:\msys64\mingw64\bin;C:\go118\bin;%PATH%
+- set GOROOT=C:\go118
 - ps: >-
     $VerbosePreference = 'Continue'
 


### PR DESCRIPTION
Signed-off-by: Gábor Lipták <gliptak@gmail.com>

https://github.com/Versent/saml2aws/issues/820

Build is failing https://ci.appveyor.com/project/davidobrien1985/saml2aws/branch/master

I don't have a way to test this PR

https://www.appveyor.com/docs/windows-images-software/
https://www.appveyor.com/docs/lang/go/