### PR TITLE
Fix broken playwright-go link in the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The process goes something like this:
   * [Akamai](pkg/provider/akamai/README.md)
   * OneLogin
   * NetIQ
-  * Browser, this uses [playwright-go](github.com/mxschmitt/playwright-go) to run a sandbox chromium window.
+  * Browser, this uses [playwright-go](https://github.com/playwright-community/playwright-go) to run a sandbox chromium window.
   * [Auth0](pkg/provider/auth0/README.md) NOTE: Currently, MFA not supported
 * AWS SAML Provider configured
 


### PR DESCRIPTION
The project moved from `github.com/mxschmitt/playwright-go` to `github.com/playwright-community/playwright-go`.