### PR TITLE
Add multiple authenticator support for Keycloak

### DIFF
--- a/pkg/provider/keycloak/example/mfapage2authenticators.html
+++ b/pkg/provider/keycloak/example/mfapage2authenticators.html
@@ -1,0 +1,93 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN"  "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml" class="login-pf">
+
+<head>
+    <meta charset="utf-8">
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <meta name="robots" content="noindex, nofollow">
+
+            <meta name="viewport" content="width=device-width,initial-scale=1"/>
+    <title>        Log in to Keycloak
+</title>
+    <link rel="icon" href="/auth/resources/3.3.0.final/login/keycloak/img/favicon.ico" />
+            <link href="/auth/resources/3.3.0.final/login/keycloak/lib/patternfly/css/patternfly.css" rel="stylesheet" />
+            <link href="/auth/resources/3.3.0.final/login/keycloak/lib/zocial/zocial.css" rel="stylesheet" />
+            <link href="/auth/resources/3.3.0.final/login/keycloak/css/login.css" rel="stylesheet" />
+<SCRIPT> if (typeof history.replaceState === 'function') {  history.replaceState({}, "some title", "https://wolfebook-2001:8443/auth/realms/master/login-actions/authenticate?execution=a718db5b-6d9e-40a2-a895-4f4505e6f464&client_id=urn%3Aamazon%3Awebservices"); }</SCRIPT></head>
+
+<body class="">
+    <div id="kc-logo"><a href="http://www.keycloak.org"><div id="kc-logo-wrapper"></div></a></div>
+
+    <div id="kc-container" class="">
+        <div id="kc-container-wrapper" class="">
+
+            <div id="kc-header" class="col-xs-12 col-sm-8 col-md-8 col-lg-7">
+                <div id="kc-header-wrapper" class="">        <div class="kc-logo-text"><span>Keycloak</span></div>
+</div>
+            </div>
+
+
+            <div id="kc-content" class="col-sm-12 col-md-12 col-lg-12 container">
+                <div id="kc-content-wrapper" class="row">
+
+
+                    <div id="kc-form" class="col-xs-12 col-sm-8 col-md-8 col-lg-7 login">
+                        <div id="kc-form-wrapper" class="">
+        <form id="kc-totp-login-form" class="form-horizontal" action="https://id.example.com/auth/realms/master/login-actions/authenticate?code=1SYK2D1kwKyOO7JyriHDfP_e9-rNes91_uzfqi8Dc94&execution=a718db5b-6d9e-40a2-a895-4f4505e6f464&client_id=urn%3Aamazon%3Awebservices" method="post">
+            <div class="form-group">
+                    <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+                            <input id="kc-otp-credential-0" class="pf-c-tile__input" type="radio" name="selectedCredentialId" value="aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa" checked="checked">
+                            <label for="kc-otp-credential-0" class="pf-c-tile" tabindex="0">
+                                <span class="pf-c-tile__header">
+                                    <span class="pf-c-tile__icon">
+                                      <i class="fa fa-mobile" aria-hidden="true"></i>
+                                    </span>
+                                    <span class="pf-c-tile__title">FreeOTP</span>
+                                </span>
+                            </label>
+                            <input id="kc-otp-credential-1" class="pf-c-tile__input" type="radio" name="selectedCredentialId" value="bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb" >
+                            <label for="kc-otp-credential-1" class="pf-c-tile" tabindex="1">
+                                <span class="pf-c-tile__header">
+                                    <span class="pf-c-tile__icon">
+                                      <i class="fa fa-mobile" aria-hidden="true"></i>
+                                    </span>
+                                    <span class="pf-c-tile__title">Google Authenticator</span>
+                                </span>
+                            </label>
+                    </div>
+                </div>
+                
+
+            <div class="form-group">
+                <div class="col-xs-12 col-sm-12 col-md-4 col-lg-3">
+                    <label for="totp" class="control-label">One-time code</label>
+                </div>
+
+                <div class="col-xs-12 col-sm-12 col-md-8 col-lg-9">
+                    <input id="totp" name="totp" autocomplete="off" type="text" class="form-control" autofocus />
+                </div>
+            </div>
+
+            <div class="form-group">
+                <div id="kc-form-options" class="col-xs-4 col-sm-5 col-md-offset-4 col-md-4 col-lg-offset-3 col-lg-5">
+                    <div class="">
+                    </div>
+                </div>
+
+                <div id="kc-form-buttons" class="col-xs-8 col-sm-7 col-md-4 col-lg-4 submit">
+                    <div class="">
+                        <input class="btn btn-primary btn-lg" name="login" id="kc-login" type="submit" value="Log in"/>
+                        <input class="btn btn-default btn-lg" name="cancel" id="kc-cancel" type="submit" value="Cancel"/>
+                    </div>
+                </div>
+            </div>
+        </form>
+                        </div>
+                    </div>
+
+                </div>
+            </div>
+        </div>
+    </div>
+</body>
+</html>


### PR DESCRIPTION
This change enables usage of more than one authenticators in KeyCloak.
It tries all the authenticators one-by-one until one of them succeeds.

Previously only the first Authenticator was respected.

Resolves #838