### PR TITLE
fix gh-845: handle relative URL in authSubmitURL

### DIFF
--- a/pkg/provider/adfs/adfs.go
+++ b/pkg/provider/adfs/adfs.go
@@ -88,6 +88,19 @@ func (ac *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 
 	if authSubmitURL == "" {
 		return samlAssertion, fmt.Errorf("unable to locate IDP authentication form submit URL")
+	} else if strings.HasPrefix(authSubmitURL, "/") {
+		//
+		// The server returned a relative URL. Make it absolute.
+		//
+		parsedUrl, err := url.Parse(adfsURL)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to parse ADFS URL")
+		}
+		parsedPath, err := url.Parse(authSubmitURL)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to parse authSubmitURL fragment")
+		}
+		authSubmitURL = parsedUrl.ResolveReference(parsedPath).String()
 	}
 
 	doc, err = ac.submit(authSubmitURL, authForm)


### PR DESCRIPTION
Similar to #368, this PR addresses #845 by detecting the relative URL and using the `adfsURL` to build an absolute URL for form submission.