### PR TITLE
Add `bgresponse: js_enabled` to challenge post too.

### DIFF
--- a/pkg/provider/googleapps/googleapps.go
+++ b/pkg/provider/googleapps/googleapps.go
@@ -326,6 +326,8 @@ func (kc *Client) loadLoginPage(submitURL string, referer string, authForm url.V
 
 func (kc *Client) loadChallengePage(submitURL string, referer string, authForm url.Values, loginDetails *creds.LoginDetails) (*goquery.Document, error) {
 
+	authForm.Set("bgresponse", "js_enabled")
+
 	req, err := http.NewRequest("POST", submitURL, strings.NewReader(authForm.Encode()))
 	if err != nil {
 		return nil, errors.Wrap(err, "error retrieving login form")


### PR DESCRIPTION
`loadFirstPage` function sends `bgresponse: enabled` to form data before posting, but this also needs to be done during the challenge POST, or you'll receive the infamous "This browser does not support Javascript.." message.

Small note: I haven't touched `go` outside of this project, so I'm unsure if there's a better way to do this, but this worked for me.