### PR TITLE
Fix ADFS auth when using MFA with number matching

### DIFF
--- a/pkg/provider/adfs/adfs.go
+++ b/pkg/provider/adfs/adfs.go
@@ -135,7 +135,15 @@ func (ac *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 			doc.Find("input").Each(func(i int, s *goquery.Selection) {
 				updatePassthroughFormData(azureForm, s)
 			})
-			sel := doc.Find("p#instructions")
+			sel := doc.Find("p#validEntropyNumber")
+			if sel.Index() != -1 {
+				if instructions != sel.Text() {
+					instructions = sel.Text()
+					log.Println("Open your Microsoft Authenticator app and tap the number you see below to sign in.")
+					log.Println(instructions)
+				}
+			}
+			sel = doc.Find("p#instructions")
 			if sel.Index() != -1 {
 				if instructions != sel.Text() {
 					instructions = sel.Text()


### PR DESCRIPTION
Based on usage it looks like p#instruction is populated via javascript after page load. The entropy number is not present in the p#instructions element.

https://docs.microsoft.com/en-us/azure/active-directory/authentication/how-to-mfa-number-match