### PR TITLE
Use Visual Studio 2019 for Appveyor

### DIFF
--- a/.appveyor/appveyor.yml
+++ b/.appveyor/appveyor.yml
@@ -1,4 +1,5 @@
 skip_non_tags: true
+image: Visual Studio 2019
 clone_folder: c:\gopath\src\github.com\versent\saml2aws
 environment:
   GOPATH: c:\gopath


### PR DESCRIPTION
after merging #827, Appveyor still failed https://ci.appveyor.com/project/davidobrien1985/saml2aws/builds/44234589

looking into it further, it might be that Appveyor runs on older Windows image with no current Golang

https://www.appveyor.com/updates/
https://www.appveyor.com/docs/windows-images-software/#golang
https://www.appveyor.com/docs/build-environment/

I don't have a way to test this PR

#820 
