### PR TITLE
fix infinite loop for keycloak

### DIFF
--- a/pkg/provider/keycloak/keycloak.go
+++ b/pkg/provider/keycloak/keycloak.go
@@ -101,7 +101,7 @@ func (kc *Client) doAuthenticate(authCtx *authContext, loginDetails *creds.Login
 	}
 
 	samlResponse, err := extractSamlResponse(doc)
-	if err != nil && authCtx.authenticatorIndexValid {
+	if err != nil && authCtx.authenticatorIndexValid && passwordValid(doc) {
 		return kc.doAuthenticate(authCtx, loginDetails)
 	}
 	return samlResponse, err
@@ -350,6 +350,18 @@ func extractSamlResponse(doc *goquery.Document) (string, error) {
 		}
 	})
 	return samlAssertion, err
+}
+
+func passwordValid(doc *goquery.Document) bool {
+	var valid = true
+	doc.Find("span#input-error").Each(func(i int, s *goquery.Selection) {
+		text := s.Text()
+		if strings.Contains(text, "Invalid username or password.") {
+			valid = false
+			return
+		}
+	})
+	return valid
 }
 
 func containsTotpForm(doc *goquery.Document) bool {


### PR DESCRIPTION
This is side effect of https://github.com/Versent/saml2aws/pull/839.
If you use wrong id/pw, it will cause an infinite loop.
To prevent this, I add a validation logic for invalid password.

@wolfeidau please check this pr.