### PR TITLE
Ptsier/onelogin saml v2

### DIFF
--- a/pkg/provider/onelogin/onelogin.go
+++ b/pkg/provider/onelogin/onelogin.go
@@ -112,7 +112,7 @@ func (c *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error) 
 		return "", errors.Wrap(err, "error encoding authreq")
 	}
 
-	authSubmitURL := fmt.Sprintf("https://%s/api/2/saml_assertion", host)
+	authSubmitURL := "https://api.us.onelogin.com/api/2/saml_assertion"
 
 	req, err := http.NewRequest("POST", authSubmitURL, &authBody)
 	if err != nil {


### PR DESCRIPTION
Fixes #778 .  @rodmatos has an open PR to fix this which this PR is based on (https://github.com/Versent/saml2aws/pull/780), but that PR is slightly incorrect (see commit 2fd27b1835d51ce3847e2fae3aa094592a7f09eb).

The v1 api is still available, but has started to break randomly at our company, so updating to v2 seems worthwhile.

[Documentation for the /1/saml_assertion](https://developers.onelogin.com/api-docs/1/saml-assertions/generate-saml-assertion).
[Documentation for the new /2/saml_assertion](https://developers.onelogin.com/api-docs/2/saml-assertions/generate-saml-assertion).