### PR TITLE
README.md - Added note about SigV4A support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Aside from Okta, most of the providers in this project are using screen scraping
 
 1. AWS defaults to session tokens being issued with a duration of up to 3600 seconds (1 hour), this can now be configured as per [Enable Federated API Access to your AWS Resources for up to 12 hours Using IAM Roles](https://aws.amazon.com/blogs/security/enable-federated-api-access-to-your-aws-resources-for-up-to-12-hours-using-iam-roles/) and `--session-duration` flag.
 2. Every SAML provider is different, the login process, MFA support is pluggable and therefore some work may be needed to integrate with your identity server
+3. By default, the temporary security credentials returned **do not support SigV4A**. If you need SigV4A support then you must set the `AWS_STS_REGIONAL_ENDPOINTS` enviornment variable to `regional` when calling `saml2aws` so that [aws-sdk-go](https://github.com/aws/aws-sdk-go) uses a regional STS endpoint instead of the global one. See the note at the bottom of [Signing AWS API requests](https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html#signature-versions) and [AWS STS Regionalized endpoints](https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html).
 
 ## Install
 


### PR DESCRIPTION
This is only a documentation change to the README.md file about support for SigV4A.

By default, the credentials returned by `saml2aws` do not support SigV4A. In order to enable SigV4A support you must use a regional STS endpoint which can be controlled via the `AWS_STS_REGIONAL_ENDPOINTS` environment variable which is picked up by aws-sdk-go.

I ran into this problem while trying to access an S3 Multi-Region Access Point with credentials provided via `saml2aws`. Direct access to my S3 buckets behind the MRAP worked fine but trying to go through the MRAP would always result in an HTTP 500 error from AWS with no useful information.

AWS Support finally pointed me to the note at the bottom of [Signing AWS API requests](https://docs.aws.amazon.com/general/latest/gr/signing_aws_api_requests.html#signature-versions) which eventually led me to [AWS STS Regionalized endpoints](https://docs.aws.amazon.com/sdkref/latest/guide/feature-sts-regionalized-endpoints.html) which has the information about setting the `AWS_STS_REGIONAL_ENDPOINTS` environment variable.