### PR TITLE
Draft: Updating to allow browser provider to work with Gov Cloud

### DIFF
--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -197,6 +197,7 @@ func resolveLoginDetails(account *cfg.IDPAccount, loginFlags *flags.LoginExecFla
 
 	// log.Printf("%s %s", savedUsername, savedPassword)
 
+	loginDetails.UseGovCloud = loginFlags.CommonFlags.UseGovCloud
 	// if you supply a username in a flag it takes precedence
 	if loginFlags.CommonFlags.Username != "" {
 		loginDetails.Username = loginFlags.CommonFlags.Username
@@ -217,7 +218,7 @@ func resolveLoginDetails(account *cfg.IDPAccount, loginFlags *flags.LoginExecFla
 		loginDetails.ClientSecret = loginFlags.CommonFlags.ClientSecret
 	}
 
-	// log.Printf("loginDetails %+v", loginDetails)
+	log.Printf("loginDetails %+v", loginDetails)
 
 	// if skip prompt was passed just pass back the flag values
 	if loginFlags.CommonFlags.SkipPrompt {

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -83,6 +83,7 @@ func main() {
 	app.Flag("disable-keychain", "Do not use keychain at all. This will also disable Okta sessions & remembering MFA device. (env: SAML2AWS_DISABLE_KEYCHAIN)").Envar("SAML2AWS_DISABLE_KEYCHAIN").BoolVar(&commonFlags.DisableKeychain)
 	app.Flag("region", "AWS region to use for API requests, e.g. us-east-1, us-gov-west-1, cn-north-1 (env: SAML2AWS_REGION)").Envar("SAML2AWS_REGION").Short('r').StringVar(&commonFlags.Region)
 	app.Flag("prompter", "The prompter to use for user input (default, pinentry)").StringVar(&commonFlags.Prompter)
+	app.Flag("use-gov-cloud", "The user is in gov cloud").Envar("SAML2AWS_USE_GOVCLOUD").BoolVar(&commonFlags.UseGovCloud)
 
 	// `configure` command and settings
 	cmdConfigure := app.Command("configure", "Configure a new IDP account.")

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -58,6 +58,7 @@ type IDPAccount struct {
 	DisableRememberDevice bool   `ini:"disable_remember_device"` // used by Okta
 	DisableSessions       bool   `ini:"disable_sessions"`        // used by Okta
 	Prompter              string `ini:"prompter"`
+	UseGovCloud           bool   `ini:"use_gov_cloud"`
 }
 
 func (ia IDPAccount) String() string {
@@ -91,7 +92,8 @@ func (ia IDPAccount) String() string {
   Profile: %s
   RoleARN: %s
   Region: %s
-}`, appID, policyID, oktaCfg, ia.URL, ia.Username, ia.Provider, ia.MFA, ia.SkipVerify, ia.AmazonWebservicesURN, ia.SessionDuration, ia.Profile, ia.RoleARN, ia.Region)
+  UseGovCloud: %v
+}`, appID, policyID, oktaCfg, ia.URL, ia.Username, ia.Provider, ia.MFA, ia.SkipVerify, ia.AmazonWebservicesURN, ia.SessionDuration, ia.Profile, ia.RoleARN, ia.Region, ia.UseGovCloud)
 }
 
 // Validate validate the required / expected fields are set
@@ -150,6 +152,7 @@ func NewIDPAccount() *IDPAccount {
 		AmazonWebservicesURN: DefaultAmazonWebservicesURN,
 		SessionDuration:      DefaultSessionDuration,
 		Profile:              DefaultProfile,
+		UseGovCloud:          false,
 	}
 }
 

--- a/pkg/creds/creds.go
+++ b/pkg/creds/creds.go
@@ -11,4 +11,5 @@ type LoginDetails struct {
 	URL               string
 	StateToken        string // used by Okta
 	OktaSessionCookie string // used by Okta
+	UseGovCloud       bool   // Use Gov Cloud
 }

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -33,6 +33,7 @@ type CommonFlags struct {
 	DisableRememberDevice bool
 	DisableSessions       bool
 	Prompter              string
+	UseGovCloud           bool
 }
 
 // LoginExecFlags flags for the Login / Exec commands
@@ -42,6 +43,7 @@ type LoginExecFlags struct {
 	DuoMFAOption      string
 	ExecProfile       string
 	CredentialProcess bool
+	UseGovCloud       bool
 }
 
 type ConsoleFlags struct {
@@ -65,6 +67,12 @@ func ApplyFlagOverrides(commonFlags *CommonFlags, account *cfg.IDPAccount) {
 
 	if commonFlags.SkipVerify {
 		account.SkipVerify = commonFlags.SkipVerify
+	}
+
+	if commonFlags.UseGovCloud {
+		account.UseGovCloud = commonFlags.UseGovCloud
+	} else {
+		account.UseGovCloud = false
 	}
 
 	if commonFlags.IdpProvider != "" {

--- a/pkg/provider/browser/browser.go
+++ b/pkg/provider/browser/browser.go
@@ -14,11 +14,12 @@ var logger = logrus.WithField("provider", "browser")
 
 // Client client for browser based Identity Provider
 type Client struct {
+	UseGovCloud bool
 }
 
 // New create new browser based client
 func New(idpAccount *cfg.IDPAccount) (*Client, error) {
-	return &Client{}, nil
+	return &Client{UseGovCloud: idpAccount.UseGovCloud}, nil
 }
 
 func (cl *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error) {
@@ -52,7 +53,11 @@ func (cl *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 		return "", err
 	}
 
-	r := page.WaitForRequest("https://signin.aws.amazon.com/saml")
+	awsSamlUrl := "https://signin.aws.amazon.com/saml"
+	if cl.UseGovCloud {
+		awsSamlUrl = "https://signin.amazonaws-us-gov.com/saml"
+	}
+	r := page.WaitForRequest(awsSamlUrl)
 	data, err := r.PostData()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
While reviewing the code I noted that the Browser provider code had the following code:
	r := page.WaitForRequest("https://signin.aws.amazon.com/saml")
	data, err := r.PostData()
	if err != nil {
		return "", err
	}
Unfortunately for those using GovCloud, that path will not be valid.   I've made a hacky change (as I'm fairly unfamiliar with the code base) to add a Login Exec flag use-gov-cloud to indicate down the chain that the user wants to use gov cloud and updated the browser provider to alternate the URL accordingly.