### PR TITLE
Support U2F on Linux

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -61,6 +61,9 @@ jobs:
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
 
+    - name: Install dependency required for linux builds
+      run: sudo apt-get update && sudo apt-get install -y libudev-dev
+
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,12 +3,12 @@ name: release
 on:
   push:
     tags:
-      - '*'
+    - '*'
 
 jobs:
   release:
     name: release
-    runs-on: macOS-latest
+    runs-on: ubuntu-latest
     steps:
 
     - name: Set up Go 1.x
@@ -18,6 +18,9 @@ jobs:
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2
+
+    - name: Install dependency required for linux builds
+      run: sudo apt-get update && sudo apt-get install -y libudev-dev
 
     - name: GoReleaser
       uses: goreleaser/goreleaser-action@v2

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -17,6 +17,14 @@ builds:
     - amd64
     - arm64
     - arm
+  overrides:
+    - goos: linux
+      goarch: amd64
+      goamd64: v1
+      tags:
+        - hidraw
+      env:
+        - CGO_ENABLED=1
 archives:
   - format: tar.gz
     wrap_in_directory: false

--- a/README.md
+++ b/README.md
@@ -633,6 +633,8 @@ region                  = us-east-1
 ```
 ## Building
 
+### macOS
+
 To build this software on osx clone to the repo to `$GOPATH/src/github.com/versent/saml2aws` and ensure you have `$GOPATH/bin` in your `$PATH`.
 
 ```
@@ -655,6 +657,26 @@ Before raising a PR please run the linter.
 
 ```
 make lint-fix
+```
+
+### Linux
+
+To build this software on Debian/Ubuntu, you need to install a build dependency:
+
+```
+sudo apt install libudev-dev
+```
+
+You also need [GoReleaser](https://github.com/goreleaser/goreleaser) installed, and the binary (or a symlink) in `bin/goreleaser`.
+
+```
+ln -s $(command -v goreleaser) bin/goreleaser
+```
+
+Then you can build:
+
+```
+make build
 ```
 
 ## Environment vars


### PR DESCRIPTION
This PR enables U2F support on Linux amd64. It builds on the work done in, and supersedes, #592.

There are no code changes, just build configuration updates:

* Pass `-tags=hidraw` to `go build` on Linux amd64, which enables U2F as per [the documentation](https://github.com/marshallbrekka/go-u2fhost#linux) in the underlying U2F library.
* Install the `libudev-dev` package and use `CGO_ENABLED=1` on Linux, because U2F support uses libudev.
* Update the Github workflows to build the package correctly on Linux (untested).
* Update the build documentation in the README.

Closes: #419 
Closes: #592

Note that this changes the release builder from macos to ubuntu. I have no way of testing the resulting macos binary to see if it still works, so would appreciate if someone else could confirm this.