### PR TITLE
Use --clean with goreleaser

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -74,4 +74,4 @@ jobs:
       uses: goreleaser/goreleaser-action@v4
       with:
         version: latest
-        args: build --snapshot --rm-dist --config .goreleaser.${{ matrix.os }}.yml
+        args: build --snapshot --clean --config .goreleaser.${{ matrix.os }}.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,6 +35,6 @@ jobs:
       uses: goreleaser/goreleaser-action@v4
       with:
         version: latest
-        args: release --rm-dist --config .goreleaser.${{ matrix.os }}.yml
+        args: release --clean --config .goreleaser.${{ matrix.os }}.yml
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -38,9 +38,9 @@ install:
 
 build: $(BIN_DIR)/goreleaser
 ifeq ($(OS),Darwin)
-	$(BIN_DIR)/goreleaser build --snapshot --rm-dist --config $(CURDIR)/.goreleaser.macos-latest.yml
+	$(BIN_DIR)/goreleaser build --snapshot --clean --config $(CURDIR)/.goreleaser.macos-latest.yml
 else ifeq ($(OS),Linux)
-	$(BIN_DIR)/goreleaser build --snapshot --rm-dist --config $(CURDIR)/.goreleaser.ubuntu-latest.yml
+	$(BIN_DIR)/goreleaser build --snapshot --clean --config $(CURDIR)/.goreleaser.ubuntu-latest.yml
 else
 	$(error Unsupported build OS: $(OS))
 endif


### PR DESCRIPTION
https://github.com/Versent/saml2aws/actions/runs/4390419924/jobs/7688852022

```
    • DEPRECATED: --rm-dist was deprecated in favor of --clean, check https://goreleaser.com/deprecations#-rm-dist for more details
```