### PR TITLE
[AzureAD] Fix broken HTML parser of AzureAD integration

### DIFF
--- a/pkg/provider/aad/aad.go
+++ b/pkg/provider/aad/aad.go
@@ -15,6 +15,7 @@ import (
 	"github.com/PuerkitoBio/goquery"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+
 	"github.com/versent/saml2aws/v2/pkg/cfg"
 	"github.com/versent/saml2aws/v2/pkg/creds"
 	"github.com/versent/saml2aws/v2/pkg/prompter"
@@ -670,8 +671,9 @@ func (ac *Client) getJsonFromConfig(resBodyStr string) string {
 	 * <script><![CDATA[  $Config=......; ]]>
 	 */
 	startIndex := strings.Index(resBodyStr, "$Config=") + 8
-	endIndex := startIndex + strings.Index(resBodyStr[startIndex:], ";")
-	return resBodyStr[startIndex:endIndex]
+	endIndex := startIndex + strings.Index(resBodyStr[startIndex:], "//]]>") - 1
+	untrimmedJsonStr := resBodyStr[startIndex:endIndex]
+	return untrimmedJsonStr[:strings.LastIndex(untrimmedJsonStr, "}")+1]
 }
 
 func (ac *Client) responseBodyAsString(body io.ReadCloser) (string, error) {

--- a/pkg/provider/aad/aad_test.go
+++ b/pkg/provider/aad/aad_test.go
@@ -7,10 +7,12 @@ import (
 	"encoding/base64"
 	"encoding/hex"
 	"encoding/json"
+	"fmt"
 	"math"
 	mrand "math/rand"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"strconv"
 	"sync"
 	"testing"
@@ -18,6 +20,7 @@ import (
 
 	"github.com/google/uuid"
 	"github.com/stretchr/testify/require"
+
 	"github.com/versent/saml2aws/v2/mocks"
 	"github.com/versent/saml2aws/v2/pkg/cfg"
 	"github.com/versent/saml2aws/v2/pkg/creds"
@@ -486,5 +489,19 @@ func TestAad_UnmarshallMfaResponseWithoutEntropy(t *testing.T) {
 
 	if mfaResp.Entropy != 0 {
 		t.Errorf("Entropy is %d and should have been 0", mfaResp.Entropy)
+	}
+}
+
+func TestAad_getJsonFromConfigNoLineBreak(t *testing.T) {
+	for _, i := range []string{"LoginEmbeddedJsonLineBreak", "LoginEmbeddedJsonNoLineBreak"} {
+		t.Run(i, func(t *testing.T) {
+			data, err := os.ReadFile(fmt.Sprintf("testdata/%s.html", i))
+			require.Nil(t, err)
+			c := Client{}
+			s := c.getJsonFromConfig(string(data))
+			var v interface{}
+			err = json.Unmarshal([]byte(s), &v)
+			require.Nil(t, err)
+		})
 	}
 }

--- a/pkg/provider/aad/testdata/LoginEmbeddedJsonLineBreak.html
+++ b/pkg/provider/aad/testdata/LoginEmbeddedJsonLineBreak.html
@@ -1,0 +1,11 @@
+  <meta name="robots" content="none" />
+
+  <script type="text/javascript">//<![CDATA[
+  $Config={"name": "value&amp;with ampersand"};//]]></script>
+  <script type="text/javascript">//<![CDATA[
+
+  //]]>
+  </script>
+
+</body>
+</html>

--- a/pkg/provider/aad/testdata/LoginEmbeddedJsonNoLineBreak.html
+++ b/pkg/provider/aad/testdata/LoginEmbeddedJsonNoLineBreak.html
@@ -1,0 +1,12 @@
+  <meta name="robots" content="none" />
+
+  <script type="text/javascript">//<![CDATA[
+  $Config={"name": "value&amp;with ampersand"};
+  //]]></script>
+  <script type="text/javascript">//<![CDATA[
+
+  //]]>
+  </script>
+
+</body>
+</html>


### PR DESCRIPTION
JSON that is embedded in a script tag can have ";" inside which breaks the parser. This change doesn't make the parser cleaner but at least handles such cases properly
