### PR TITLE
Fix wget instructions for linux setup in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ While brew is available for Linux you can also run the following without using a
 
 ```
 CURRENT_VERSION=$(curl -Ls https://api.github.com/repos/Versent/saml2aws/releases/latest | grep 'tag_name' | cut -d'v' -f2 | cut -d'"' -f1)
-wget -c https://github.com/Versent/saml2aws/releases/download/v${CURRENT_VERSION}/saml2aws_${CURRENT_VERSION}_linux_amd64.tar.gz -O - | tar -xzv -C ~/.local/bin
+wget -c "https://github.com/Versent/saml2aws/releases/download/v${CURRENT_VERSION}/saml2aws_${CURRENT_VERSION}_linux_amd64.tar.gz" -O - | tar -xzv -C ~/.local/bin
 chmod u+x ~/.local/bin/saml2aws
 hash -r
 saml2aws --version


### PR DESCRIPTION
The ticks are required to prevent that some shells escape the braces