### PR TITLE
Fix #1010: split u2f build

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-20.04, macOS-latest, macos-11]
+        os: [ubuntu-latest, macOS-latest, macos-11]
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
@@ -40,7 +40,7 @@ jobs:
 
   linting:
     name: lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Set up Go 1.x
         uses: actions/setup-go@v4
@@ -59,7 +59,7 @@ jobs:
     name: coverage
     permissions:
       contents: read
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [build]
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -80,6 +80,7 @@ jobs:
     strategy:
       matrix:
         os:
+          - ubuntu-latest
           - ubuntu-20.04
           - macos-latest
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -48,7 +48,7 @@ jobs:
 
   windows-msi:
     name: Build Windows MSI and upload to release
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     needs: [release]
     if: >-  # https://github.com/actions/runner/issues/491
       always() &&

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,6 +19,7 @@ jobs:
       max-parallel: 1
       matrix:
         os:
+        - ubuntu-latest
         - ubuntu-20.04
         - macos-latest
     runs-on: ${{ matrix.os }}

--- a/.goreleaser.ubuntu-latest.yml
+++ b/.goreleaser.ubuntu-latest.yml
@@ -1,5 +1,5 @@
 ---
-project_name: saml2aws-u2f
+project_name: saml2aws
 
 builds:
 - main: ./cmd/saml2aws/main.go
@@ -10,20 +10,18 @@ builds:
   ldflags:
     - -s -w -X main.Version={{.Version}} -X main.commit={{.Commit}} -X main.date={{.Date}}
   goos:
+    - windows
     - linux
   goarch:
     - amd64
-  overrides:
-    - goos: linux
-      goarch: amd64
-      goamd64: v1
-      tags:
-        - hidraw
-      env:
-        - CGO_ENABLED=1
+    - arm64
+    - arm
 archives:
   - format: tar.gz
     wrap_in_directory: false
+    format_overrides:
+      - goos: windows
+        format: zip
     # remove README and LICENSE
     files:
       - LICENSE.md

--- a/.goreleaser.ubuntu-latest.yml
+++ b/.goreleaser.ubuntu-latest.yml
@@ -16,6 +16,12 @@ builds:
     - amd64
     - arm64
     - arm
+  overrides:
+    - goos: linux
+      goarch: amd64
+      goamd64: v1
+      env:
+        - CGO_ENABLED=0
 archives:
   - format: tar.gz
     wrap_in_directory: false

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ endif
 ifeq ($(OS),Darwin)
 	goreleaser build --snapshot --clean --config $(CURDIR)/.goreleaser.macos-latest.yml
 else ifeq ($(OS),Linux)
-	goreleaser build --snapshot --clean --config $(CURDIR)/.goreleaser.ubuntu-20.04.yml
+	goreleaser build --snapshot --clean --config $(CURDIR)/.goreleaser.ubuntu-latest.yml
 else
 	$(error Unsupported build OS: $(OS))
 endif

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ chmod u+x ~/.local/bin/saml2aws
 hash -r
 saml2aws --version
 ```
-If U2F support is required then there are separate builds for this, Use the following download URL instead:
+If U2F support is required then there are separate builds for this - use the following download URL instead:
 ```
 wget -c "https://github.com/Versent/saml2aws/releases/download/v${CURRENT_VERSION}/saml2aws-u2f_${CURRENT_VERSION}_linux_amd64.tar.gz" -O - | tar -xzv -C ~/.local/bin
 ```

--- a/README.md
+++ b/README.md
@@ -120,6 +120,10 @@ chmod u+x ~/.local/bin/saml2aws
 hash -r
 saml2aws --version
 ```
+If U2F support is required then there are separate builds for this, Use the following download URL instead:
+```
+wget -c "https://github.com/Versent/saml2aws/releases/download/v${CURRENT_VERSION}/saml2aws-u2f_${CURRENT_VERSION}_linux_amd64.tar.gz" -O - | tar -xzv -C ~/.local/bin
+```
 
 #### Using Make
 


### PR DESCRIPTION
Split out the build of Linux with U2F support so that the standard build is statically linked without U2F support (as before) and there's a separate build with Linux U2F support. This gives the portability and compatibility of the static binary by default, while those who need U2F support have a release build that has reasonable glibc compatibility.

#1010