### PR TITLE
Handling PingOne device names within button elements

### DIFF
--- a/pkg/provider/pingone/example/selectdevicebutton.html
+++ b/pkg/provider/pingone/example/selectdevicebutton.html
@@ -1,0 +1,125 @@
+<!DOCTYPE html><html><head>
+    <meta charset="utf-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta name="format-detection" content="telephone=no"/>
+    <meta http-equiv="x-ua-compatible" content="IE=edge"/>
+    <title>Change Authenticating Device</title>
+    <link rel="stylesheet" href="/pingid/assets/css/main-v21.219.css" media="screen" title="no title" charset="utf-8"/>
+    <link rel="stylesheet" media="screen" type="text/css" href="/pingid/assets/css/jsdisabled.css"/>
+    <script type="text/javascript" src="/pingid/assets/js/jquery-1.11.1.min.js"></script>
+    <script type="text/javascript" src="/pingid/assets/js/wizards/devices.js"></script>
+    <script type="text/javascript" src="/pingid/assets/js/utils/signout.js"></script>
+</head>
+<body>
+<noscript>
+    
+
+
+
+
+
+
+
+
+<!DOCTYPE html>
+<html>
+<head>
+	<title></title>
+	<meta name="viewport" content="width=device-width, initial-scale=1.0" />
+	<meta name = "format-detection" content = "telephone=no">
+	<link rel="stylesheet" href="/pingid/assets/css/jsdisabled.css" media="screen" title="no title" charset="utf-8">
+</head>
+<body>
+    <div class="nojspage dialog">
+            
+
+            <div class="window error">
+                <div class="content">
+                    <div class="status"></div>
+        			<div class="title-text">
+        			    Important
+                    </div>
+
+        	            <div class="error-text">
+        					<div class="text">
+        					    PingID requires Javascript to be enabled. If the problem persists, please contact your administrator.
+        					</div>
+        	            </div>
+
+                </div>
+            </div>
+
+            <div class="admin-message" /><!-- admin message pushes footer to the bottom of the page -->
+
+            <div class="footer">
+                <div class="pingid_logo"></div>
+                <div class="copyright">
+                    Copyright &copy; 2003-2019 Ping Identity Corporation. All rights reserved.
+                </div>
+            </div>
+    </div>
+</body>
+</html>
+    <style type="text/css">
+		.dialog { display:none; }
+	</style>
+</noscript>
+<div class="dialog">
+    <div class="window change-device">
+        <div class="content">
+            <div class="title">
+                Change Authenticating Device
+            </div>
+            <ul class="device-list">
+                
+                    <li class="device mobile-phone selected" data-id="3270134077889335000">
+                        <button>
+                            iPhone
+                            <div class="device-name">iPhone</div>
+                        </button>
+                    </li>
+                
+                    <li class="device mobile-phone" data-id="3964291169487703000">
+                        <button>
+                            Android
+                            <div class="device-name">Android</div>
+                        </button>
+                    </li>
+                
+            </ul>
+
+            <form id="device-form" name="device-form" action="/pingid/ppm/devices" method="post">
+                <input type="hidden" name="csrfToken" id="csrfToken" value="217c0510-62ab-4033-a8b9-4836121b8ae4" encode="false"/>
+                <input type="hidden" name="deviceId" id="deviceId" value="3270134077889335000" encode="false"/>
+
+                <div class="buttons">
+                	
+                    	<a class="button settings-btn" href="https://authenticator.pingone.com/pingid/ppm/settings">Settings</a>
+                    
+                    <input type="Submit" value="Sign On" class="primary"/>
+                </div>
+                
+                    <div class="rescueCode">
+                        <a class="forgotYourDevice" href="https://authenticator.pingone.com/pingid/ppm/rescueCodeDevices">
+                            Forgot your device?</a>
+                    </div>
+                
+                
+            </form>
+        </div>
+    </div>
+
+    <div class="admin-message"></div>
+
+    <div class="footer">
+        <div class="logo"></div>
+        <div class="copyright">
+            Copyright © 2003-2019 Ping Identity Corporation. All rights reserved.
+        </div>
+    </div>
+    <form method="POST" action="/pingid/ppm/signoutredirect" id="signoutForm">
+        <input type="hidden" name="csrfToken" id="csrfToken" value="217c0510-62ab-4033-a8b9-4836121b8ae4" encode="false"/>
+    </form>
+</div>
+
+</body></html>

--- a/pkg/provider/pingone/pingone.go
+++ b/pkg/provider/pingone/pingone.go
@@ -248,21 +248,13 @@ func (ac *Client) handleRefresh(ctx context.Context, doc *goquery.Document, _ *h
 }
 
 func (ac *Client) handleFormSelectDevice(ctx context.Context, doc *goquery.Document, res *http.Response) (context.Context, *http.Request, error) {
-	deviceList := make(map[string]string)
-	var deviceNameList []string
-
-	doc.Find("ul.device-list > li").Each(func(_ int, s *goquery.Selection) {
-		deviceId, _ := s.Attr("data-id")
-		deviceName, _ := s.Find("a > div.device-name").Html()
-		if deviceName == "" {
-			deviceName, _ = s.Find("button > div.device-name").Html()
-		}
-
-		logger.WithField("device name", deviceName).WithField("device id", deviceId).Debug("Select Device")
-		deviceList[deviceName] = deviceId
-		deviceNameList = append(deviceNameList, deviceName)
-	})
-
+	var deviceMap = findDeviceMap(doc)
+	deviceNameList := make([]string, len(deviceMap))
+	i := 0
+	for key := range deviceMap {
+		deviceNameList[i] = key
+		i++
+	}
 	var chooseDevice = prompter.Choose("Select which MFA Device to use", deviceNameList)
 
 	form, err := page.NewFormFromDocument(doc, "")
@@ -270,7 +262,7 @@ func (ac *Client) handleFormSelectDevice(ctx context.Context, doc *goquery.Docum
 		return ctx, nil, errors.Wrap(err, "error extracting select device form")
 	}
 
-	form.Values.Set("deviceId", deviceList[deviceNameList[chooseDevice]])
+	form.Values.Set("deviceId", deviceMap[deviceNameList[chooseDevice]])
 	form.URL, err = makeAbsoluteURL(form.URL, makeBaseURL(res.Request.URL))
 	if err != nil {
 		return ctx, nil, err
@@ -349,4 +341,20 @@ func makeAbsoluteURL(v string, base string) (string, error) {
 		return pathURL.String(), nil
 	}
 	return baseURL.ResolveReference(pathURL).String(), nil
+}
+
+func findDeviceMap(doc *goquery.Document) map[string]string {
+	deviceList := make(map[string]string)
+
+	doc.Find("ul.device-list > li").Each(func(_ int, s *goquery.Selection) {
+		deviceId, _ := s.Attr("data-id")
+		deviceName, _ := s.Find("a > div.device-name").Html()
+		if deviceName == "" {
+			deviceName, _ = s.Find("button > div.device-name").Html()
+		}
+
+		logger.WithField("device name", deviceName).WithField("device id", deviceId).Debug("Select Device")
+		deviceList[deviceName] = deviceId
+	})
+	return deviceList
 }

--- a/pkg/provider/pingone/pingone.go
+++ b/pkg/provider/pingone/pingone.go
@@ -254,6 +254,9 @@ func (ac *Client) handleFormSelectDevice(ctx context.Context, doc *goquery.Docum
 	doc.Find("ul.device-list > li").Each(func(_ int, s *goquery.Selection) {
 		deviceId, _ := s.Attr("data-id")
 		deviceName, _ := s.Find("a > div.device-name").Html()
+		if deviceName == "" {
+			deviceName, _ = s.Find("button > div.device-name").Html()
+		}
 
 		logger.WithField("device name", deviceName).WithField("device id", deviceId).Debug("Select Device")
 		deviceList[deviceName] = deviceId

--- a/pkg/provider/pingone/pingone_test.go
+++ b/pkg/provider/pingone/pingone_test.go
@@ -3,6 +3,7 @@ package pingone
 import (
 	"bytes"
 	"os"
+	"reflect"
 	"testing"
 
 	"github.com/PuerkitoBio/goquery"
@@ -37,6 +38,32 @@ func TestDocTypes(t *testing.T) {
 
 		if tt.fn(doc) != tt.expected {
 			t.Errorf("expect doc check of %v to be %v", tt.file, tt.expected)
+		}
+	}
+}
+
+var deviceNameTests = []struct {
+	file     string
+	expected map[string]string
+}{
+	{"example/selectdevice.html", map[string]string{"iPhone": "3270134077889335000", "Android": "3964291169487703000"}},
+	{"example/selectdevicebutton.html", map[string]string{"iPhone": "3270134077889335000", "Android": "3964291169487703000"}},
+}
+
+func TestFindDeviceMap(t *testing.T) {
+	for _, tt := range deviceNameTests {
+		data, err := os.ReadFile(tt.file)
+		require.Nil(t, err)
+
+		doc, err := goquery.NewDocumentFromReader(bytes.NewReader(data))
+		require.Nil(t, err)
+
+		deviceMap := findDeviceMap(doc)
+
+		eq := reflect.DeepEqual(deviceMap, tt.expected)
+
+		if eq != true {
+			t.Errorf("expected deviceMap %v to be %v", deviceMap, tt.expected)
 		}
 	}
 }


### PR DESCRIPTION
In the environment I'm working in, the PingOne device names are within a 'button' element rather than an 'a' element. This change checks for device names within a 'button' element if there is no device name found within the 'a' element.