### PR TITLE
add mkdir to installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ saml2aws --version
 While brew is available for Linux you can also run the following without using a package manager.
 
 ```
+mkdir -p ~/.local/bin
 CURRENT_VERSION=$(curl -Ls https://api.github.com/repos/Versent/saml2aws/releases/latest | grep 'tag_name' | cut -d'v' -f2 | cut -d'"' -f1)
 wget -c "https://github.com/Versent/saml2aws/releases/download/v${CURRENT_VERSION}/saml2aws_${CURRENT_VERSION}_linux_amd64.tar.gz" -O - | tar -xzv -C ~/.local/bin
 chmod u+x ~/.local/bin/saml2aws


### PR DESCRIPTION
The README's installation instructions assume the existence of `~/.local/bin/`. This adds a `mkdir` command to ensure that that directory is present.