### PR TITLE
Fix Okta WebAuthn challenge

### DIFF
--- a/pkg/provider/okta/okta_webauthn.go
+++ b/pkg/provider/okta/okta_webauthn.go
@@ -85,10 +85,10 @@ func (d *FidoClient) ChallengeU2F() (*SignedAssertion, error) {
 	}
 	request := &u2fhost.AuthenticateRequest{
 		Challenge: d.ChallengeNonce,
-		Facet:     d.AppID,
+		Facet:     "https://" + d.AppID,
 		AppId:     d.AppID,
 		KeyHandle: d.KeyHandle,
-		WebAuthn:  false,
+		WebAuthn:  true,
 	}
 	// do the change
 	prompted := false

--- a/pkg/provider/okta/okta_webauthn_test.go
+++ b/pkg/provider/okta/okta_webauthn_test.go
@@ -66,12 +66,12 @@ func TestChallengeWebAuthnU2F(t *testing.T) {
 			request := &u2fhost.AuthenticateRequest{
 				Challenge:          challengeNonce,
 				AppId:              appID,
-				Facet:              appID,
+				Facet:              "https://" + appID,
 				KeyHandle:          keyHandle,
 				ChannelIdPublicKey: nil,
 				ChannelIdUnused:    false,
 				CheckOnly:          false,
-				WebAuthn:           false,
+				WebAuthn:           true,
 			}
 			response := &u2fhost.AuthenticateResponse{}
 			device.On("Authenticate", request).Return(response, nil)


### PR DESCRIPTION
PR #1039 introduced a change to okta_webauthn.go that most probably
is a relic from the development phase of the Duo integration (ref:
82b3ba36c28b94c0138e874177b830b08c1468bb).

Since the Duo integration implements its own ChallengeU2F, this should
be safe to revert.
