### PR TITLE
feat: disambiguate Okta U2F tokens using the ID

### DIFF
--- a/pkg/provider/okta/okta_test.go
+++ b/pkg/provider/okta/okta_test.go
@@ -316,7 +316,7 @@ func TestOktaParseMfaIdentifer(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.title, func(t *testing.T) {
-			identifier, authName := parseMfaIdentifer(resp, test.index)
+			identifier, authName, _ := parseMfaIdentifer(resp, test.index)
 			assert.Equal(t, test.identifier, identifier)
 			assert.Equal(t, test.authName, authName)
 		})


### PR DESCRIPTION
This changes adds the ID of the token to the string in the prompt, which allows users to distinguish tokens with non-unique authNames.

This also fixes the issue where if the authName is the same for all tokens, the first token is always chosen by saml2aws regardless of user selection.

Closes: #910 