### PR TITLE
add another regex for finding state tokens

### DIFF
--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -607,12 +607,22 @@ func (oc *Client) getStateToken(req *http.Request, loginDetails *creds.LoginDeta
 }
 
 func getStateTokenFromOktaPageBody(responseBody string) (string, error) {
-	re := regexp.MustCompile("var stateToken = [\"|'](.*)[\"|'];")
-	match := re.FindStringSubmatch(responseBody)
-	if len(match) < 2 {
-		return "", errors.New("cannot find state token")
+	regexes := []*regexp.Regexp{
+		regexp.MustCompile("var stateToken = [\"|'](.*)[\"|'];"),
+		// Found on the "extra verification" page
+		// hiding in a Javascript object
+		regexp.MustCompile(`"stateToken":"([^"]*)"`),
 	}
-	return strings.Replace(match[1], `\x2D`, "-", -1), nil
+
+	for _, re := range regexes {
+		match := re.FindStringSubmatch(responseBody)
+		if len(match) >= 2 {
+			return strings.Replace(match[1], `\x2D`, "-", -1), nil
+		}
+	}
+
+	return "", fmt.Errorf("cannot find state token in %v", responseBody)
+
 }
 
 func parseMfaIdentifer(json string, arrayPosition int) (string, string, string) {

--- a/pkg/provider/okta/okta.go
+++ b/pkg/provider/okta/okta.go
@@ -621,7 +621,7 @@ func getStateTokenFromOktaPageBody(responseBody string) (string, error) {
 		}
 	}
 
-	return "", fmt.Errorf("cannot find state token in %v", responseBody)
+	return "", errors.New("cannot find state token")
 
 }
 

--- a/pkg/provider/okta/okta_test.go
+++ b/pkg/provider/okta/okta_test.go
@@ -53,6 +53,12 @@ func TestGetStateTokenFromOktaPageBody(t *testing.T) {
 			stateToken: "12345-6789",
 			err:        nil,
 		},
+		{
+			title:      "javascript state token inside JSON",
+			body:       `U0h8","stateToken":"c0ffeeda7e","helpLinks":{"help"`,
+			stateToken: "c0ffeeda7e",
+			err:        nil,
+		},
 	}
 	for _, test := range tests {
 		t.Run(test.title, func(t *testing.T) {


### PR DESCRIPTION
I've been having a weird intermittent issue, where trying to log in would sometimes fail with an opaque message: 

```
Error authenticating to IdP.: failed to getStateToken: error retrieving saml response: cannot find state token
```

After a bunch of digging, I discovered that sometimes Okta will request "extra verification" in the form of another 2fa request. Not a big deal, but for whatever reason that page doesn't store the state token as a single variable. Instead, it's burried deep in a blob of almost-JSON. 

This change lets us dig up state tokens from those pages as well, which mostly fixes the "cannot find state token" message