### PR TITLE
[#1055]: Join full command string to not execute each portion as individual commands

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -78,6 +78,6 @@ test:
 # Note: Files written by the container will be owned by root.  This is a limitation of the Docker socket mount.
 # You may need to run `docker run --privileged --rm tonistiigi/binfmt --install all` to enable the buildx plugin.
 docker-build-environment:
-	docker build --platform=amd64 -t saml2aws/build -f Dockerfile.build .
+	docker build --platform=linux/amd64 -t saml2aws/build -f Dockerfile.build .
 	docker run -it --rm -v /var/run/docker.sock:/var/run/docker.sock -e BUILDX_CONFIG=$(PWD)/.buildtemp -e GOPATH=$(PWD)/.buildtemp -e GOTMPDIR=$(PWD)/.buildtemp -e GOCACHE=$(PWD)/.buildtemp/.cache -e GOENV=$(PWD)/.buildtemp/env -v $(PWD):$(PWD) -w $(PWD) saml2aws/build:latest
 .PHONY: docker-build-environment

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -6,6 +6,7 @@ package shell
 import (
 	"os"
 	"os/exec"
+	"strings"
 )
 
 // ExecShellCmd exec shell command using the default shell
@@ -13,11 +14,14 @@ func ExecShellCmd(cmdline []string, envVars []string) error {
 	return prepCmd(cmdline, envVars).Run()
 }
 
-func prepCmd(cs []string, envVars []string) *exec.Cmd {
-	cmd := exec.Command(cs[0], cs[1:]...)
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
-	cmd.Env = append(os.Environ(), envVars...)
-	return cmd
+func prepCmd(cmdline []string, envVars []string) *exec.Cmd {  
+  c := strings.Join(cmdline, " ")
+
+  cs := []string{"/bin/sh", "-c", c}
+  cmd := exec.Command(cs[0], cs[1:]...)  
+  cmd.Stdin = os.Stdin  
+  cmd.Stdout = os.Stdout  
+  cmd.Stderr = os.Stderr  
+  cmd.Env = append(os.Environ(), envVars...)  
+  return cmd  
 }

--- a/pkg/shell/shell.go
+++ b/pkg/shell/shell.go
@@ -15,13 +15,13 @@ func ExecShellCmd(cmdline []string, envVars []string) error {
 }
 
 func prepCmd(cmdline []string, envVars []string) *exec.Cmd {  
-  c := strings.Join(cmdline, " ")
+	c := strings.Join(cmdline, " ")
 
-  cs := []string{"/bin/sh", "-c", c}
-  cmd := exec.Command(cs[0], cs[1:]...)  
-  cmd.Stdin = os.Stdin  
-  cmd.Stdout = os.Stdout  
-  cmd.Stderr = os.Stderr  
-  cmd.Env = append(os.Environ(), envVars...)  
-  return cmd  
+	cs := []string{"/bin/sh", "-c", c}
+	cmd := exec.Command(cs[0], cs[1:]...)  
+	cmd.Stdin = os.Stdin  
+	cmd.Stdout = os.Stdout  
+	cmd.Stderr = os.Stderr  
+	cmd.Env = append(os.Environ(), envVars...)  
+	return cmd  
 }


### PR DESCRIPTION
chore(Makefile): change platform flag to use linux/amd64 instead of amd64 for better compatibility

fix(shell.go): modify prepCmd function to execute shell commands using /bin/sh instead of directly invoking the command to improve compatibility with different shells. (Fixes #1055)