### PR TITLE
Update golangci-lint

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -53,6 +53,7 @@ jobs:
         uses: golangci/golangci-lint-action@v3
         with:
           version: v1.53.2
+          args: --timeout=2m
 
   coverage:
     name: coverage

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -52,7 +52,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v3
         with:
-          version: v1.51.2
+          version: v1.53.2
 
   coverage:
     name: coverage

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -2,13 +2,10 @@ linters:
   disable-all: true
   enable:
     - goimports
-    - deadcode
     - errcheck
     - gosimple
     - govet
     - ineffassign
     - staticcheck
-    - structcheck
     - typecheck
     - unused
-    - varcheck


### PR DESCRIPTION
- Upgrade golangci-lint to v1.53.2
- Increase timeout of golangci-lint
- Remove deprecated golangci-lint linters

This addresses the linter timeouts as seen in #1059 and #1070.