### PR TITLE
Fix small mistakes in function doc comments

### DIFF
--- a/pkg/prompter/survey.go
+++ b/pkg/prompter/survey.go
@@ -63,7 +63,7 @@ func (cli *CliPrompter) Choose(pr string, options []string) int {
 	return 0
 }
 
-// StringRequired prompt for string which is required
+// String prompt for string with a default
 func (cli *CliPrompter) String(pr string, defaultValue string) string {
 	val := ""
 	prompt := &survey.Input{

--- a/pkg/provider/okta/okta_duo_u2f.go
+++ b/pkg/provider/okta/okta_duo_u2f.go
@@ -26,7 +26,7 @@ type ResponseData struct {
 	KeyHandle     string `json:"keyHandle"`
 }
 
-// NewFidoClient returns a new initialized FIDO1-based WebAuthnClient, representing a single device
+// NewDUOU2FClient returns a new initialized DUOU2F-based WebAuthnClient, representing a single device
 func NewDUOU2FClient(challengeNonce, appID, version, keyHandle, stateToken string, deviceFinder DeviceFinder) (*DUOU2FClient, error) {
 	var device u2fhost.Device
 	var err error


### PR DESCRIPTION
This commit fixes two spots where function comments were mismatched with the code, likely from copy-paste accidents.

Background: I'm doing a research study on function comments that may be improvable. You can find more info and a short and optional anonymous survey [here](https://forms.office.com/e/yHv4PRXM2i).
 
Thanks for reviewing!
