### PR TITLE
Add 5m timeout to page.WaitForRequest

### DIFF
--- a/pkg/provider/browser/browser.go
+++ b/pkg/provider/browser/browser.go
@@ -13,6 +13,8 @@ import (
 
 var logger = logrus.WithField("provider", "browser")
 
+var TimeoutPageWaitForRequest = newPageWaitForRequestOptions(300000)
+
 // Client client for browser based Identity Provider
 type Client struct {
 	Headless bool
@@ -94,7 +96,7 @@ var getSAMLResponse = func(page playwright.Page, loginDetails *creds.LoginDetail
 	}
 
 	logger.Info("waiting ...")
-	r, _ := page.WaitForRequest(signin_re)
+	r, _ := page.WaitForRequest(signin_re, TimeoutPageWaitForRequest)
 	data, err := r.PostData()
 	if err != nil {
 		return "", err
@@ -122,4 +124,8 @@ func (cl *Client) Validate(loginDetails *creds.LoginDetails) error {
 	}
 
 	return nil
+}
+
+func newPageWaitForRequestOptions(timeout float64) playwright.PageWaitForRequestOptions {
+	return playwright.PageWaitForRequestOptions{Timeout: &timeout}
 }

--- a/pkg/provider/browser/browser_test.go
+++ b/pkg/provider/browser/browser_test.go
@@ -107,7 +107,7 @@ func TestGetSAMLResponse(t *testing.T) {
 	regex, err := signinRegex()
 	assert.Nil(t, err)
 	page.Mock.On("Goto", url).Return(resp, nil)
-	page.Mock.On("WaitForRequest", regex).Return(req)
+	page.Mock.On("WaitForRequest", regex, TimeoutPageWaitForRequest).Return(req)
 	req.Mock.On("PostData").Return(params.Encode(), nil)
 	// loginDetails := &creds.LoginDetails{
 	//	URL: url,

--- a/pkg/provider/browser/browser_test.go
+++ b/pkg/provider/browser/browser_test.go
@@ -62,7 +62,7 @@ func TestNoBrowserDriverFail(t *testing.T) {
 	assert.ErrorContains(t, err, "could not start driver")
 }
 
-func fakeSAMLResponse(page playwright.Page, loginDetails *creds.LoginDetails) (string, error) {
+func fakeSAMLResponse(page playwright.Page, loginDetails *creds.LoginDetails, client *Client) (string, error) {
 	return response, nil
 }
 
@@ -96,6 +96,14 @@ func TestGetSAMLResponse(t *testing.T) {
 			</saml:EncryptedAssertion>
 	</samlp:Response>
 `
+
+	idpAccount := cfg.IDPAccount{
+		Headless: true,
+		Timeout:  100000,
+	}
+
+	client, err := New(&idpAccount)
+	assert.Nil(t, err)
 	params := url.Values{}
 	params.Add("foo1", "bar1")
 	params.Add("SAMLResponse", samlp)
@@ -107,12 +115,46 @@ func TestGetSAMLResponse(t *testing.T) {
 	regex, err := signinRegex()
 	assert.Nil(t, err)
 	page.Mock.On("Goto", url).Return(resp, nil)
-	page.Mock.On("WaitForRequest", regex, TimeoutPageWaitForRequest).Return(req)
+	page.Mock.On("WaitForRequest", regex, client.waitForRequestTimeout()).Return(req)
 	req.Mock.On("PostData").Return(params.Encode(), nil)
 	// loginDetails := &creds.LoginDetails{
 	//	URL: url,
 	//}
-	// samlResp, err := getSAMLResponse(page, loginDetails)
+	// samlResp, err := getSAMLResponse(page, loginDetails, client)
 	// assert.Nil(t, err)
 	// assert.Equal(t, samlp, samlResp)
+}
+
+func TestWaitForRequestOptions(t *testing.T) {
+	timeout := float64(100000)
+	idpAccount := cfg.IDPAccount{
+		Headless: true,
+		Timeout:  int(timeout),
+	}
+
+	client, err := New(&idpAccount)
+	assert.Nil(t, err)
+
+	options := client.waitForRequestTimeout()
+	if *options.Timeout != timeout {
+		t.Errorf("Unexpected value for timeout [%.0f]: expected [%.0f]", *options.Timeout, timeout)
+	}
+}
+
+func TestWaitForRequestOptionsDefaultTimeout(t *testing.T) {
+	idpAccount := cfg.IDPAccount{
+		Headless: true,
+		Timeout:  1000,
+	}
+
+	client, err := New(&idpAccount)
+
+	if err != nil {
+		t.Errorf("Unable to create browser")
+	}
+
+	options := client.waitForRequestTimeout()
+	if *options.Timeout != DEFAULT_TIMEOUT {
+		t.Errorf("Unexpected value for timeout [%.0f]: expected [%.0f]", *options.Timeout, DEFAULT_TIMEOUT)
+	}
 }


### PR DESCRIPTION
I didn't see an appropriate place to add/update a unit test for this but I have been using it locally and it fixes the issue.  Doesn't seem like an external configuration flag is required but may be if users continue to have issues.