### PR TITLE
[Bug fix] remove redirect to about:blank page

### DIFF
--- a/pkg/provider/browser/browser.go
+++ b/pkg/provider/browser/browser.go
@@ -141,10 +141,7 @@ var getSAMLResponse = func(page playwright.Page, loginDetails *creds.LoginDetail
 	}
 
 	logger.Info("waiting ...")
-	r, _ := page.ExpectRequest(signin_re, func() error {
-		_, err := page.Goto("about:blank")
-		return err
-	}, client.expectRequestTimeout())
+	r, _ := page.ExpectRequest(signin_re, nil, client.expectRequestTimeout())
 	data, err := r.PostData()
 	if err != nil {
 		return "", err


### PR DESCRIPTION
Solves #1161

### Background:
The code change that was introduced in https://github.com/Versent/saml2aws/pull/1157/files#diff-5cd59a5a8d31c61bb9c035ee3524699cd8e97b722683501d805074f7d11b7ee9R102-R103

was done because of a signature change with the new release:
https://github.com/playwright-community/playwright-go/blob/main/page.go#L567

The `cb` method is not an error callback, but a general callback which is not mandatory:

https://github.com/playwright-community/playwright-go/blob/ddc7abdd06db016d63664de1ab08870195085ddb/waiter.go#L144

### The issue
The redirect to blank page created an unwanted side-effect that did not allow saml2aws to continue with AWS role selection as described in #1161.

This is the fix.

FYI @gliptak 