### PR TITLE
Always print roles with list-roles

### DIFF
--- a/cmd/saml2aws/commands/list_roles.go
+++ b/cmd/saml2aws/commands/list_roles.go
@@ -117,12 +117,7 @@ func ListRoles(loginFlags *flags.LoginExecFlags) error {
 }
 
 func listRoles(awsRoles []*saml2aws.AWSRole, samlAssertion string, loginFlags *flags.LoginExecFlags) error {
-	if len(awsRoles) == 1 {
-		log.Println("")
-		log.Println("Only one role to assume. Will be automatically assumed on login")
-		log.Println(awsRoles[0].RoleARN)
-		return nil
-	} else if len(awsRoles) == 0 {
+	if len(awsRoles) == 0 {
 		return errors.New("no roles available")
 	}
 


### PR DESCRIPTION
We use list-roles in a wraper script to gather the available okta lists. I think skipping the output is not properly placed in this function call, because the intention of it is to actually list them, not do any shortcuts. Hence I removed this check for only one list, as I do not see why it should behave differently in this case.