### PR TITLE
fix(dependabot): labels could not be found

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,10 +5,10 @@ updates:
     schedule:
       interval: "weekly"
     labels:
-      - "type: dependencies"
+      - "dependencies"
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
       interval: "weekly"
     labels:
-      - "type: dependencies"
+      - "dependencies"


### PR DESCRIPTION
Fix dependabot not automatically apply labels to Pull Requests due to `The following labels could not be found: type: dependencies.`

Here is the link to how the labels values should be used https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#labels 