### PR TITLE
Browser provider - Autofill works with more authentication forms

### DIFF
--- a/pkg/provider/browser/browser.go
+++ b/pkg/provider/browser/browser.go
@@ -192,9 +192,7 @@ var autoFill = func(page playwright.Page, loginDetails *creds.LoginDetails) erro
 		return err
 	}
 
-	//If the submit button exists in the page, click it
-	// Press Enter to send the current form
-	// Find the submit button of the form that the password field is in
+	// Find the submit button or input of the form that the password field is in
 	submitLocator := page.Locator("form", playwright.PageLocatorOptions{
 		Has: passwordField,
 	}).Locator("[type='submit']")
@@ -202,6 +200,7 @@ var autoFill = func(page playwright.Page, loginDetails *creds.LoginDetails) erro
 	if err != nil {
 		return err
 	}
+
 	// when submit locator exists, Click it
 	if count > 0 {
 		return submitLocator.Click()
@@ -209,7 +208,6 @@ var autoFill = func(page playwright.Page, loginDetails *creds.LoginDetails) erro
 		_, err := page.Evaluate(`document.querySelector('input[type="password"]').form.submit()`, nil)
 		return err
 	}
-
 }
 
 func signinRegex() (*regexp.Regexp, error) {

--- a/pkg/provider/browser/browser.go
+++ b/pkg/provider/browser/browser.go
@@ -192,8 +192,24 @@ var autoFill = func(page playwright.Page, loginDetails *creds.LoginDetails) erro
 		return err
 	}
 
+	//If the submit button exists in the page, click it
 	// Press Enter to send the current form
-	return keyboard.Press("Enter")
+	// Find the submit button of the form that the password field is in
+	submitLocator := page.Locator("form", playwright.PageLocatorOptions{
+		Has: passwordField,
+	}).Locator("[type='submit']")
+	count, err := submitLocator.Count()
+	if err != nil {
+		return err
+	}
+	// when submit locator exists, Click it
+	if count > 0 {
+		return submitLocator.Click()
+	} else { // Use javascript to submit the form when no submit input or button is found
+		_, err := page.Evaluate(`document.querySelector('input[type="password"]').form.submit()`, nil)
+		return err
+	}
+
 }
 
 func signinRegex() (*regexp.Regexp, error) {

--- a/pkg/provider/browser/browser.go
+++ b/pkg/provider/browser/browser.go
@@ -192,10 +192,8 @@ var autoFill = func(page playwright.Page, loginDetails *creds.LoginDetails) erro
 		return err
 	}
 
-	// Find the submit button of the form that the password field is in
-	return page.Locator("form", playwright.PageLocatorOptions{
-		Has: passwordField,
-	}).Locator("input[type='submit']").Click()
+	// Press Enter to send the current form
+	return keyboard.Press("Enter")
 }
 
 func signinRegex() (*regexp.Regexp, error) {

--- a/pkg/provider/browser/example/loginpage-button-submit.html
+++ b/pkg/provider/browser/example/loginpage-button-submit.html
@@ -1,0 +1,41 @@
+<html>
+<head>
+  <title>Fake Login Page</title>
+</head>
+<body>
+<form id="form">
+  <div>
+    <label for="username"><b>Username:</b></label>
+    <input type="text" name="username" />
+  </div>
+
+  <div>
+    <label for="password"><b>Password:</b></label>
+    <input type="password" name="password" />
+  </div>
+
+  <div><button type="submit">Login</button></div>
+</form>
+
+<div id="result" style="display: none">
+  You should not see this as the form onsubmit should override this inner
+  text.
+</div>
+
+<script>
+  const submit = document.querySelector("button[type=submit]");
+  const formSection = document.getElementById("form");
+  const resultSection = document.getElementById("result");
+
+  form.onsubmit = function (event) {
+    event.preventDefault();
+    const username = event.target.elements.username.value;
+    const password = event.target.elements.password.value;
+
+    formSection.style.display = "none";
+    resultSection.style.display = "block";
+    resultSection.innerText = `${username}:${password}`;
+  };
+</script>
+</body>
+</html>

--- a/pkg/provider/browser/example/loginpage-without-submit.html
+++ b/pkg/provider/browser/example/loginpage-without-submit.html
@@ -1,0 +1,42 @@
+<html>
+<head>
+  <title>Fake Login Page</title>
+</head>
+<body>
+<form id="form" action="javascript:sform(this)">
+  <div>
+    <label for="username"><b>Username:</b></label>
+    <input type="text" name="username" />
+  </div>
+
+  <div>
+    <label for="password"><b>Password:</b></label>
+    <input type="password" name="password" />
+  </div>
+
+  <img onclick="document.getElementById('form').submit();" src="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAABgAAAAYCAYAAADgdz34AAAABHNCSVQICAgIfAhkiAAAAAlwSFlzAAAAsQAAALEBxi1JjQAAABl0RVh0U29mdHdhcmUAd3d3Lmlua3NjYXBlLm9yZ5vuPBoAAAFaSURBVEiJ7dS/S1dhGAXwjzd/lL9DcKhFAxdFXJydHJWgggqam8JRlwwEEVsSBRcVB3HQQRcJImzUIYgv5NAWREN/gOJvyOE+Fy5aCnIFEQ9cOJz3uee87/Pc+3KLG48y9GEgeJH4i0lYR3nB5sJzPcEejkNsxj3paWpDq0MVHgWHalQgQX2urinqHoTnXpJLfIIZLKETw6Ev4Ckm8CmM3uENHmM2DMfRi894kT9GhqPY0XscBs9qMt4UvB0d+IPW0BIs4xU+/CtgE98whzFUhp4N/ws28Cze20UbfuZadwb5Fj3HvLTfW7iPjyjhAC/Rjx/4FWtf43mI/fDZPh2y9r/0ArCWxI7rL6o8B5UYReMpvQF3y9CNt6i5hPm+dCYl6cBn8B1T2IngQrAindkQVtGSLdwpKKAVXRjEb+lPVirIG/RIWzKN10UaZ6jGiPSzX3Q1d9stritOAG7+OnNg3y0nAAAAAElFTkSuQmCC" />
+</form>
+
+<div id="result" style="display: none">
+  You should not see this as the form onsubmit should override this inner
+  text.
+</div>
+
+<script>
+  const formSection = document.getElementById("form");
+  const resultSection = document.getElementById("result");
+
+  function sform() {
+
+    const username = formSection.username.value;
+    const password = formSection.password.value;
+
+    formSection.style.display = "none";
+    resultSection.style.display = "block";
+    resultSection.innerText = `${username}:${password}`;
+  };
+
+
+</script>
+</body>
+</html>


### PR DESCRIPTION
Hello, 

This PR proposition updates the way the autofill func submits the form:
Instead of locating the submit button and clicking on it, it send an Enter keypress.

I had to implement this to make it works with my company authentification web form, which has no html submit button, but an image with javascript events linked to it.
