### PR TITLE
fix: enable cgo on macos builds

### DIFF
--- a/.goreleaser.macos-latest.yml
+++ b/.goreleaser.macos-latest.yml
@@ -15,6 +15,8 @@ builds:
     - amd64
     - arm64
     - arm
+  env:
+    - CGO_ENABLED=1
 archives:
   - format: tar.gz
     wrap_in_directory: false


### PR DESCRIPTION
just like it's done on https://github.com/Versent/saml2aws/blob/master/.goreleaser.ubuntu-20.04.yml#L23-L24

fixes #900 #873