### PR TITLE
Fix missing provider when passing as an argument

### DIFF
--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/alecthomas/kingpin"
 	"github.com/sirupsen/logrus"
+	"github.com/versent/saml2aws/v2"
 	"github.com/versent/saml2aws/v2/cmd/saml2aws/commands"
 	"github.com/versent/saml2aws/v2/pkg/flags"
 	"github.com/versent/saml2aws/v2/pkg/prompter"
@@ -71,7 +72,7 @@ func main() {
 	commonFlags := new(flags.CommonFlags)
 	app.Flag("config", "Path/filename of saml2aws config file (env: SAML2AWS_CONFIGFILE)").Envar("SAML2AWS_CONFIGFILE").StringVar(&commonFlags.ConfigFile)
 	app.Flag("idp-account", "The name of the configured IDP account. (env: SAML2AWS_IDP_ACCOUNT)").Envar("SAML2AWS_IDP_ACCOUNT").Short('a').Default("default").StringVar(&commonFlags.IdpAccount)
-	app.Flag("idp-provider", "The configured IDP provider. (env: SAML2AWS_IDP_PROVIDER)").Envar("SAML2AWS_IDP_PROVIDER").EnumVar(&commonFlags.IdpProvider, "Akamai", "AzureAD", "ADFS", "ADFS2", "Browser", "GoogleApps", "Ping", "JumpCloud", "Okta", "OneLogin", "PSU", "KeyCloak", "F5APM", "Shibboleth", "ShibbolethECP", "NetIQ", "Auth0")
+	app.Flag("idp-provider", "The configured IDP provider. (env: SAML2AWS_IDP_PROVIDER)").Envar("SAML2AWS_IDP_PROVIDER").EnumVar(&commonFlags.IdpProvider, saml2aws.MFAsByProvider.Names()...)
 	app.Flag("browser-type", "The configured browser type when the IDP provider is set to Browser. if not set 'chromium' will be used. (env: SAML2AWS_BROWSER_TYPE)").Envar("SAML2AWS_BROWSER_TYPE").EnumVar(&commonFlags.BrowserType, "chromium", "firefox", "webkit", "chrome", "chrome-beta", "chrome-dev", "chrome-canary", "msedge", "msedge-beta", "msedge-dev", "msedge-canary")
 	app.Flag("browser-executable-path", "The configured browser full path when the IDP provider is set to Browser. If set, no browser download will be performed and the executable path will be used instead. (env: SAML2AWS_BROWSER_EXECUTABLE_PATH)").Envar("SAML2AWS_BROWSER_EXECUTABLE_PATH").StringVar(&commonFlags.BrowserExecutablePath)
 	app.Flag("browser-autofill", "Configures browser to autofill the username and password. (env: SAML2AWS_BROWSER_AUTOFILL)").Envar("SAML2AWS_BROWSER_AUTOFILL").BoolVar(&commonFlags.BrowserAutoFill)


### PR DESCRIPTION
This PR will fix missing providers that exists in the interactive "provider" drop-down but when attempt to pass it in as an argument from the command line, it doesn't matches the hard-coded list which is a sub-set of the providers in the drop-down list.

Current version of saml2aws v2.36.16: (note the enum value, it is missing a few values like PingOne)
```
➜  saml2aws_darwin_arm64 git:(1294-missing-idp-provider) ✗ saml2aws configure --idp-provider=PingOne
saml2aws: error: enum value must be one of Akamai,AzureAD,ADFS,ADFS2,Browser,GoogleApps,Ping,JumpCloud,Okta,OneLogin,PSU,KeyCloak,F5APM,Shibboleth,ShibbolethECP,NetIQ,Auth0, got 'PingOne', try --help
```

The binary built to test the current PR: (note the enum value, PingOne is there)
```
➜  saml2aws_darwin_arm64 git:(1294-missing-idp-provider) ✗ ./saml2aws configure --idp-provider=PingOn
saml2aws: error: enum value must be one of ADFS,ADFS2,Akamai,Auth0,Authentik,AzureAD,Browser,F5APM,GoogleApps,JumpCloud,KeyCloak,NetIQ,Okta,OneLogin,Ping,PingNTLM,PingOne,Shibboleth,ShibbolethECP, got 'PingOn', try --help
➜  saml2aws_darwin_arm64 git:(1294-missing-idp-provider) ✗ ./saml2aws configure --idp-provider=PingOne
? Please choose a provider:  [Use arrows to move, type to filter]
  Okta
  OneLogin
  Ping
  PingNTLM
> PingOne
  Shibboleth
  ShibbolethECP
failed to input configuration: error selecting provider file: bad input
➜  saml2aws_darwin_arm64 git:(1294-missing-idp-provider) ✗
```

Closes #1294