### PR TITLE
fix: credential-process flag remove logs [#1293]

### DIFF
--- a/README.md
+++ b/README.md
@@ -832,7 +832,8 @@ DUMP_CONTENT=true saml2aws login --verbose
 
 [Credential Process](https://github.com/awslabs/awsprocesscreds) is a convenient way of interfacing credential providers with the AWS Cli.
 
-You can use `saml2aws` as a credential provider by simply configuring it and then adding a profile to the AWS configuration. `saml2aws` has a flag `--credential-process` generating an output with the right JSON format.
+You can use `saml2aws` as a credential provider by simply configuring it and then adding a profile to the AWS configuration. `saml2aws` has a flag `--credential-process` generating an output with the right JSON format, as well as a flag `--quiet` that will block the logging from being displayed.
+The AWS credential file (typically ~/.aws/credentials) has precedence over the credential_process provider. That means that if credentials are present in the file, the credential process will not trigger. To counter that you can override the aws credential location of `saml2aws` to another file using `--credential-file` or specifying it during `configure`.
 
 The AWS credential file (typically ~/.aws/credentials) has precedence over the credential_process provider. That means that if credentials are present in the file, the credential process will not trigger.
 

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -178,7 +178,7 @@ func main() {
 		errtpl = "%+v\n"
 	}
 
-	if *quiet || (command == cmdLogin.FullCommand() && loginFlags.CredentialProcess) {
+	if *quiet {
 		log.SetOutput(io.Discard)
 		logrus.SetOutput(io.Discard)
 	}


### PR DESCRIPTION
A change made between v2.36.15 to v2.36.16 (current version at time of writing) had introduced an unwanted side-effect of not showing MFA phone numbers when using the `--credential-process` flag as it also implicitly applies `--quiet`. 

The line in question that was introduced by a commit that made it into v2.36.16 is https://github.com/Versent/saml2aws/blob/08035b93069c0ca518b13d1ef905e08b95bc1269/cmd/saml2aws/main.go#L172

Looking at the PR https://github.com/Versent/saml2aws/commit/08035b93069c0ca518b13d1ef905e08b95bc1269#diff-700f078cb6e14d20af7c09e73a1507604a85cfb66d6c54db727f45dc21a13d2a, I do not see any potential side-effects in removing the additional conditions in the "quiet" condition statement to "quiet" the logs.