### PR TITLE
fix: gha setup go cache issue [#1319]

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version-file: "go.mod"
 
       - name: Test
         run: |
@@ -47,7 +47,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version-file: "go.mod"
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -101,7 +101,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version-file: "go.mod"
 
       - name: Install dependency required for linux builds
         if: matrix.os == 'ubuntu-20.04'

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,13 +14,13 @@ jobs:
       matrix:
         os: [ubuntu-latest, macOS-latest, macos-12]
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
 
       - name: Test
         run: |
@@ -41,13 +41,13 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
           go-version: 1.21.x
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
 
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v6
@@ -63,14 +63,17 @@ jobs:
     needs: [build]
     steps:
       - uses: actions/checkout@v4
+
       - uses: actions/download-artifact@v4
         with:
           name: ubuntu-latest_reports
           path: reports
+
       - uses: actions/download-artifact@v4
         with:
           name: macOS-latest_reports
           path: reports
+
       - uses: actions/download-artifact@v4
         with:
           name: macos-12_reports
@@ -92,13 +95,13 @@ jobs:
           - macos-latest
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: 1.20.x
-
-      - name: Check out code into the Go module directory
-        uses: actions/checkout@v4
+          go-version: 1.21.x
 
       - name: Install dependency required for linux builds
         if: matrix.os == 'ubuntu-20.04'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,11 @@ name: release
 on:
   push:
     tags:
-      - '*'
+      - "*"
   workflow_dispatch:
     inputs:
       tag:
-        description: The tag to run against. This trigger only runs the MSI builder.
+        description: The tag to run against. This trigger runs the GoReleaser and MSI builder.
         required: true
 
 jobs:
@@ -19,44 +19,44 @@ jobs:
       max-parallel: 1
       matrix:
         os:
-        - ubuntu-latest
-        - ubuntu-20.04
-        - macos-latest
+          - ubuntu-latest
+          - ubuntu-20.04
+          - macos-latest
     runs-on: ${{ matrix.os }}
     if: github.event_name != 'workflow_dispatch'
     permissions: write-all
     steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
 
-    - name: Set up Go 1.x
-      uses: actions/setup-go@v5
-      with:
-        go-version: 1.21.x
+      - name: Set up Go 1.x
+        uses: actions/setup-go@v5
+        with:
+          go-version: 1.21.x
 
-    - name: Check out code into the Go module directory
-      uses: actions/checkout@v4
+      - name: Install dependency required for linux builds
+        if: matrix.os == 'ubuntu-20.04'
+        run: sudo apt-get update && sudo apt-get install -y libudev-dev
 
-    - name: Install dependency required for linux builds
-      if: matrix.os == 'ubuntu-20.04'
-      run: sudo apt-get update && sudo apt-get install -y libudev-dev
+      - name: Add Lowercase Repository Name to Environment
+        run: |
+          echo REPOSITORY_NAME_LOWERCASE=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
 
-    - name: Add Lowercase Repository Name to Environment
-      run: |
-        echo REPOSITORY_NAME_LOWERCASE=$(echo ${{ github.repository }} | tr '[:upper:]' '[:lower:]') >> $GITHUB_ENV
+      - uses: "docker/login-action@v3"
+        if: matrix.os == 'ubuntu-20.04'
+        with:
+          registry: "ghcr.io"
+          username: "${{ github.actor }}"
+          password: "${{ secrets.GITHUB_TOKEN }}"
 
-    - uses: "docker/login-action@v3"
-      if: matrix.os == 'ubuntu-20.04'
-      with:
-        registry: "ghcr.io"
-        username: "${{ github.actor }}"
-        password: "${{ secrets.GITHUB_TOKEN }}"
-    - name: GoReleaser
-      uses: goreleaser/goreleaser-action@v6
-      with:
-        version: latest
-        args: release --clean --config .goreleaser.${{ matrix.os }}.yml
-      env:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        IMAGE_NAME: ${{ env.REPOSITORY_NAME_LOWERCASE }}
+      - name: GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: latest
+          args: release --clean --config .goreleaser.${{ matrix.os }}.yml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_NAME: ${{ env.REPOSITORY_NAME_LOWERCASE }}
 
   windows-msi:
     name: Build Windows MSI and upload to release
@@ -64,7 +64,7 @@ jobs:
     permissions:
       contents: write
     needs: [release]
-    if: >-  # https://github.com/actions/runner/issues/491
+    if: >- # https://github.com/actions/runner/issues/491
       always() &&
       (needs.release.result == 'success' || needs.release.result == 'skipped')
     env:
@@ -72,45 +72,47 @@ jobs:
       BIN: ${{ github.workspace }}/.github/win-msi/src/bin
       WIXIMG: dactiv/wix@sha256:17d232708589641f5632f9a1ff9463ad087b192cea7b8e6012d2b47ec6af5f6c
     steps:
-    - name: Normalize tag values
-      run: |
-        if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] ; then
-            VER=${{ github.event.inputs.tag }}
-        else
-            VER=${GITHUB_REF/refs\/tags\//}
-        fi
+      - name: Normalize tag values
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]] ; then
+              VER=${{ github.event.inputs.tag }}
+          else
+              VER=${GITHUB_REF/refs\/tags\//}
+          fi
 
-        VERSION=${VER//v}
+          VERSION=${VER//v}
 
-        echo "VER_TAG=$VER" >> $GITHUB_ENV
-        echo "VERSION=$VERSION" >> $GITHUB_ENV
-        echo "ASSET=saml2aws_${VERSION}_windows_amd64.zip" >> $GITHUB_ENV
+          echo "VER_TAG=$VER" >> $GITHUB_ENV
+          echo "VERSION=$VERSION" >> $GITHUB_ENV
+          echo "ASSET=saml2aws_${VERSION}_windows_amd64.zip" >> $GITHUB_ENV
 
-    - name: Check out code
-      uses: actions/checkout@v4
+      - name: Check out code
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-    - name: Retrieve the release asset
-      id: asset
-      uses: robinraju/release-downloader@a96f54c1b5f5e09e47d9504526e96febd949d4c2  # v1.11
-      with:
-        repository: ${{ github.repository }}
-        tag: ${{ env.VER_TAG }}
-        fileName: ${{ env.ASSET }}
-        out-file-path: ${{ env.BIN }}
+      - name: Retrieve the release asset
+        id: asset
+        uses: robinraju/release-downloader@a96f54c1b5f5e09e47d9504526e96febd949d4c2 # v1.11
+        with:
+          repository: ${{ github.repository }}
+          tag: ${{ env.VER_TAG }}
+          fileName: ${{ env.ASSET }}
+          out-file-path: ${{ env.BIN }}
 
-    - name: Unzip asset
-      working-directory: ${{ env.BIN }}
-      run: unzip "${ASSET}"
+      - name: Unzip asset
+        working-directory: ${{ env.BIN }}
+        run: unzip "${ASSET}"
 
-    - name: Build MSI
-      run: |
-        # container does not run as root
-        chmod -R o+rw "${INSTALLER}"
+      - name: Build MSI
+        run: |
+          # container does not run as root
+          chmod -R o+rw "${INSTALLER}"
 
-        cat "${INSTALLER}/wix.sh" | docker run --rm -i -e VERSION -v "${INSTALLER}:/wix" ${WIXIMG} /bin/sh
+          cat "${INSTALLER}/wix.sh" | docker run --rm -i -e VERSION -v "${INSTALLER}:/wix" ${WIXIMG} /bin/sh
 
-    - name: Upload the asset to the release
-      uses: softprops/action-gh-release@a74c6b72af54cfa997e81df42d94703d6313a2d0  # v0.2.0.6.2.0.65 / v2.0.6
-      with:
-        tag_name: ${{ env.VER_TAG }}
-        files: ${{ env.INSTALLER }}/out/*.msi
+      - name: Upload the asset to the release
+        uses: softprops/action-gh-release@a74c6b72af54cfa997e81df42d94703d6313a2d0 # v0.2.0.6.2.0.65 / v2.0.6
+        with:
+          tag_name: ${{ env.VER_TAG }}
+          files: ${{ env.INSTALLER }}/out/*.msi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,8 @@ jobs:
     steps:
       - name: Check out code into the Go module directory
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Set up Go 1.x
         uses: actions/setup-go@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -32,7 +32,7 @@ jobs:
       - name: Set up Go 1.x
         uses: actions/setup-go@v5
         with:
-          go-version: 1.21.x
+          go-version-file: "go.mod"
 
       - name: Install dependency required for linux builds
         if: matrix.os == 'ubuntu-20.04'


### PR DESCRIPTION
While looking at the GitHub Action runner executing a job, I have noticed an error during the "Set up Go 1.x" stage 

```bash
Warning: Restore cache failed: Dependencies file is not found in /home/runner/work/saml2aws/saml2aws. Supported file pattern: go.sum
```

A quick look at the documentation and it had the `actions/checkout` before the `actions/setup-go`, while we had it afterwards, which probably explains why it cannot find `go.sum`.

Also (the bit that was outside the scope of the initial issue but I wanted to save multiple PRs):
- we are still using Go version 1.20 somewhere and after a quick search, I've came across a way to derive version from go.mod (https://github.com/actions/setup-go?tab=readme-ov-file#getting-go-version-from-the-gomod-file)
- ran the yaml file against a formatter, so there will be some formatting magic going on
- goreleaser wants `actions/checkout` to have "fetch-depth" of 0 for the changelog to work correctly for the gorelease release, as mentioned in the "IMPORTANT" section beneath the Workflow code block: https://github.com/goreleaser/goreleaser-action?tab=readme-ov-file#workflow 

I am more than happy to move the "also" bit to a new PR if that is more ideal?

Closes #1319 