### PR TITLE
fix(ci): fail to push windows pkg due to missing flag [#1325]

### DIFF
--- a/.appveyor/appveyor.yml
+++ b/.appveyor/appveyor.yml
@@ -52,6 +52,6 @@ artifacts:
 #  draft: true
 deploy_script:
 - ps: >-
-    choco apiKey -k $env:CHOCOLATEY_APIKEY -source https://push.chocolatey.org/
+    choco apiKey -k $env:CHOCOLATEY_APIKEY -s https://push.chocolatey.org/
 
-    choco push ./choco/${env:appName}.$(($env:APPVEYOR_REPO_TAG_NAME).Split('v')[1]).nupkg
+    choco push ./choco/${env:appName}.$(($env:APPVEYOR_REPO_TAG_NAME).Split('v')[1]).nupkg -s https://push.chocolatey.org/


### PR DESCRIPTION
- Fix "source" flag in the `choco apiKey` command to be in line with the documentation: https://docs.chocolatey.org/en-us/create/commands/api-key/
- Add "source" flag in `choco push` command
  - satisfy the response from the failed ci execution: https://ci.appveyor.com/project/davidobrien1985/saml2aws
  - using the short-hand `-s` for source to be consistent, I've checked that it does exists in https://docs.chocolatey.org/en-us/create/commands/push/
