### PR TITLE
chore(nuspec): change authors to Versent

### DIFF
--- a/choco/saml2aws.nuspec
+++ b/choco/saml2aws.nuspec
@@ -9,7 +9,7 @@
     <!-- owners is a poor name for maintainers of the package. It sticks around by this name for compatibility reasons. It basically means you. -->
     <owners>Versent, https://github.com/Versent</owners>
     <title>saml2aws (Install)</title>
-    <authors>Mark Wolfe, https://github.com/wolfeidau</authors>
+    <authors>Versent, https://github.com/Versent</authors>
     <projectUrl>https://github.com/Versent/saml2aws</projectUrl>
     <licenseUrl>https://github.com/versent/saml2aws/blob/master/LICENSE.md</licenseUrl>
     <requireLicenseAcceptance>true</requireLicenseAcceptance>


### PR DESCRIPTION
Update the authors of the package to Versent, This will also affect the displaying of authors' name in saml2aws Chocolatey package page.
![Screenshot 2024-08-07 at 8 02 18 PM](https://github.com/user-attachments/assets/72d6dc2d-92c8-4d7a-bab2-46de999b5d90)
