### PR TITLE
Implement assume-time policy limiting

### DIFF
--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -4,6 +4,7 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -363,6 +364,22 @@ func loginToStsUsingRole(account *cfg.IDPAccount, role *saml2aws.AWSRole, samlAs
 		RoleArn:         aws.String(role.RoleARN),      // Required
 		SAMLAssertion:   aws.String(samlAssertion),     // Required
 		DurationSeconds: aws.Int64(int64(account.SessionDuration)),
+	}
+
+	if account.PolicyFile != "" {
+		policy, err := ioutil.ReadFile(account.PolicyFile)
+		if err != nil {
+			return nil, errors.Wrap(err, fmt.Sprintf("Failed to load supplimental policy file: %s", account.PolicyFile))
+		}
+		params.Policy = aws.String(string(policy))
+	}
+
+	if account.PolicyARNs != "" {
+		var arns []*sts.PolicyDescriptorType
+		for _, arn := range strings.Split(account.PolicyARNs, ",") {
+			arns = append(arns, &sts.PolicyDescriptorType{Arn: aws.String(arn)})
+		}
+		params.PolicyArns = arns
 	}
 
 	log.Println("Requesting AWS credentials using SAML assertion.")

--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -4,7 +4,6 @@ import (
 	b64 "encoding/base64"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"strings"
@@ -367,7 +366,7 @@ func loginToStsUsingRole(account *cfg.IDPAccount, role *saml2aws.AWSRole, samlAs
 	}
 
 	if account.PolicyFile != "" {
-		policy, err := ioutil.ReadFile(account.PolicyFile)
+		policy, err := os.ReadFile(account.PolicyFile)
 		if err != nil {
 			return nil, errors.Wrap(err, fmt.Sprintf("Failed to load supplimental policy file: %s", account.PolicyFile))
 		}

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -83,6 +83,8 @@ func main() {
 	app.Flag("password", "The password used to login. (env: SAML2AWS_PASSWORD)").Envar("SAML2AWS_PASSWORD").StringVar(&commonFlags.Password)
 	app.Flag("mfa-token", "The current MFA token (supported in Keycloak, ADFS, GoogleApps). (env: SAML2AWS_MFA_TOKEN)").Envar("SAML2AWS_MFA_TOKEN").StringVar(&commonFlags.MFAToken)
 	app.Flag("role", "The ARN of the role to assume. (env: SAML2AWS_ROLE)").Envar("SAML2AWS_ROLE").StringVar(&commonFlags.RoleArn)
+	app.Flag("policyfile", "The file containing the supplemental AssumeRole policy. (env: SAML2AWS_POLICY_FILE)").Envar("SAML2AWS_POLICY_FILE").StringVar(&commonFlags.PolicyFile)
+	app.Flag("policyarns", "The ARN of supplemental policies to restrict the token. (env: SAML2AWS_POLICY_ARNS)").Envar("SAML2AWS_POLICY_ARNS").StringVar(&commonFlags.PolicyARNs)
 	app.Flag("aws-urn", "The URN used by SAML when you login. (env: SAML2AWS_AWS_URN)").Envar("SAML2AWS_AWS_URN").StringVar(&commonFlags.AmazonWebservicesURN)
 	app.Flag("skip-prompt", "Skip prompting for parameters during login.").BoolVar(&commonFlags.SkipPrompt)
 	app.Flag("session-duration", "The duration of your AWS Session. (env: SAML2AWS_SESSION_DURATION)").Envar("SAML2AWS_SESSION_DURATION").IntVar(&commonFlags.SessionDuration)

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -52,6 +52,8 @@ type IDPAccount struct {
 	ResourceID            string `ini:"resource_id"` // used by F5APM
 	Subdomain             string `ini:"subdomain"`   // used by OneLogin
 	RoleARN               string `ini:"role_arn"`
+	PolicyFile            string `ini:"policy_file"`
+	PolicyARNs            string `ini:"policy_arn_list"`
 	Region                string `ini:"region"`
 	HttpAttemptsCount     string `ini:"http_attempts_count"`
 	HttpRetryDelay        string `ini:"http_retry_delay"`

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -22,6 +22,8 @@ type CommonFlags struct {
 	Username              string
 	Password              string
 	RoleArn               string
+	PolicyFile            string
+	PolicyARNs            string
 	AmazonWebservicesURN  string
 	SessionDuration       int
 	SkipPrompt            bool
@@ -114,6 +116,12 @@ func ApplyFlagOverrides(commonFlags *CommonFlags, account *cfg.IDPAccount) {
 
 	if commonFlags.RoleArn != "" {
 		account.RoleARN = commonFlags.RoleArn
+	}
+	if commonFlags.PolicyFile != "" {
+		account.PolicyFile = commonFlags.PolicyFile
+	}
+	if commonFlags.PolicyARNs != "" {
+		account.PolicyARNs = commonFlags.PolicyARNs
 	}
 	if commonFlags.ResourceID != "" {
 		account.ResourceID = commonFlags.ResourceID


### PR DESCRIPTION
When an STS token is acquired, it's possible to use supplemental policies to limit the permissions of the token. One example use might be assuming an administrative role, but limiting the permissions to a read-only or security-review scope to use to provided credentials in an auditing tool. This PR implements assume-time limiting of permissions with additional managed policies or a local policy document.