### PR TITLE
Fix broken link

### DIFF
--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -170,7 +170,7 @@ func main() {
 
 	// will leave this here for a while during upgrade process
 	if *provider != "" {
-		log.Println("The --provider flag has been replaced with a new configure command. See https://github.com/versent/saml2aws/v2#adding-idp-accounts")
+		log.Println("The --provider flag has been replaced with a new configure command. See https://github.com/Versent/saml2aws#configuring-idp-accounts")
 		os.Exit(1)
 	}
 


### PR DESCRIPTION
## Background

The link that comes up when using the `--provider` flag is broken.

```sh
$ saml2aws login --provider=Ping
The --provider flag has been replaced with a new configure command. See https://github.com/versent/saml2aws/v2#adding-idp-accounts
```

## Detail

Corrected https://github.com/versent/saml2aws/v2#adding-idp-accounts link to https://github.com/Versent/saml2aws#configuring-idp-accounts .

## Additional info

The adding-idp-accounts document has been renamed to configuring-idp-accounts with this change.

https://github.com/Versent/saml2aws/commit/7bbdacc9458a61c30e652d0400cc5355f35ca4f7#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L71

Also consistent with what we have here.

https://github.com/Versent/saml2aws/blob/64255ff7019612e60de7b5139206f1c514cf4374/README.md?plain=1#L212