### PR TITLE
chore: Upgrade golangci-lint in Makefile to support toolchain directive

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ ARCH=$(shell uname -m)
 OS?=$(shell uname)
 ITERATION := 1
 
-GOLANGCI_VERSION = 1.53.2
+GOLANGCI_VERSION = 1.55.2
 GORELEASER := $(shell command -v goreleaser 2> /dev/null)
 
 SOURCE_FILES?=$$(go list ./... | grep -v /vendor/)
@@ -42,7 +42,7 @@ fmt: lint-fix
 
 install:
 	go install ./cmd/saml2aws
-.PHONY: mod
+.PHONY: install
 
 build:
 


### PR DESCRIPTION
## What's changed?

- The previous version (1.53.2) was behind the version (1.55.2) used in [GitHub Actions](https://github.com/Versent/saml2aws/blob/148bb41a9d6c1043592ff5d8484813ca545c3138/.github/workflows/go.yml#L52-L56).
- This caused issues with parsing the `toolchain` directive in `go.mod`.
- Additionally, correct the PHONY directive for `make install`.

## Before & After

```sh
$ go version
go version go1.22.5 darwin/arm64
```

### With version 1.53.2

```sh
$ make lint
--- lint all the things
level=info msg="[config_reader] Config search paths: [./ /app / /root]"
level=info msg="[config_reader] Used config file .golangci.yaml"
level=info msg="[lintersdb] Active 8 linters: [errcheck goimports gosimple govet ineffassign staticcheck typecheck unused]"
level=info msg="[loader] Go packages loading at mode 575 (imports|name|compiled_files|deps|exports_file|files|types_sizes) took 12.611667ms"
level=error msg="Running error: context loading failed: failed to load packages: failed to load with go/packages: err: exit status 1: stderr: go: errors parsing go.mod:\n/app/go.mod:3: invalid go version '1.21.0': must match format 1.23\n/app/go.mod:5: unknown directive: toolchain\n"
level=info msg="Memory: 2 samples, avg is 22.5MB, max is 22.6MB"
level=info msg="Execution took 14.768209ms"
make: *** [lint] Error 3
```

### After upgrade version to 1.55.2

```sh
$ make lint
--- lint all the things
level=info msg="[config_reader] Config search paths: [./ /app / /root]"
level=info msg="[config_reader] Used config file .golangci.yaml"
level=info msg="[lintersdb] Active 7 linters: [errcheck goimports gosimple govet ineffassign staticcheck unused]"
level=info msg="[loader] Go packages loading at mode 575 (files|name|deps|exports_file|imports|types_sizes|compiled_files) took 13.42876934s"
level=info msg="[runner/filename_unadjuster] Pre-built 0 adjustments in 16.938083ms"
level=info msg="[linters_context/goanalysis] analyzers took 11.461038284s with top 10 stages: buildir: 5.694025389s, goimports: 431.35729ms, inspect: 423.431545ms, fact_deprecated: 410.214001ms, ctrlflow: 255.992416ms, printf: 246.518339ms, isgenerated: 221.661997ms, S1038: 145.601414ms, ineffassign: 122.390001ms, errcheck: 120.113542ms"
level=info msg="[runner] Issues before processing: 52, after processing: 0"
level=info msg="[runner] Processors filtering stat (out/in): filename_unadjuster: 52/52, skip_files: 52/52, exclude: 50/50, path_prettifier: 52/52, autogenerated_exclude: 50/52, identifier_marker: 50/50, cgo: 52/52, skip_dirs: 52/52, exclude-rules: 0/50"
level=info msg="[runner] processing took 1.762294ms with stages: autogenerated_exclude: 1.334334ms, identifier_marker: 251.875µs, path_prettifier: 68.709µs, exclude-rules: 58.416µs, skip_dirs: 43.083µs, cgo: 1.875µs, filename_unadjuster: 791ns, nolint: 584ns, max_same_issues: 417ns, fixer: 417ns, exclude: 334ns, diff: 250ns, uniq_by_line: 209ns, skip_files: 167ns, source_code: 167ns, severity-rules: 166ns, sort_results: 166ns, max_from_linter: 125ns, path_prefixer: 84ns, max_per_file_from_linter: 83ns, path_shortener: 42ns"
level=info msg="[runner] linters took 2.521004917s with stages: goanalysis_metalinter: 2.519204125s"
level=info msg="File cache stats: 0 entries of total size 0B"
level=info msg="Memory: 161 samples, avg is 81.2MB, max is 490.0MB"
level=info msg="Execution took 15.969207298s"
```