### PR TITLE
added kc broker flag

### DIFF
--- a/cmd/saml2aws/commands/login.go
+++ b/cmd/saml2aws/commands/login.go
@@ -25,7 +25,6 @@ import (
 
 // Login login to ADFS
 func Login(loginFlags *flags.LoginExecFlags) error {
-
 	logger := logrus.WithField("command", "login")
 
 	account, err := buildIdpAccount(loginFlags)
@@ -256,6 +255,11 @@ func resolveLoginDetails(account *cfg.IDPAccount, loginFlags *flags.LoginExecFla
 		loginDetails.DownloadBrowser = loginFlags.DownloadBrowser
 	} else if account.DownloadBrowser {
 		loginDetails.DownloadBrowser = account.DownloadBrowser
+	}
+
+	// parse KCBroker if set
+	if account.KCBroker != "" {
+		loginDetails.KCBroker = account.KCBroker
 	}
 
 	// log.Printf("loginDetails %+v", loginDetails)

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -91,6 +91,7 @@ func main() {
 	app.Flag("disable-keychain", "Do not use keychain at all. This will also disable Okta sessions & remembering MFA device. (env: SAML2AWS_DISABLE_KEYCHAIN)").Envar("SAML2AWS_DISABLE_KEYCHAIN").BoolVar(&commonFlags.DisableKeychain)
 	app.Flag("region", "AWS region to use for API requests, e.g. us-east-1, us-gov-west-1, cn-north-1 (env: SAML2AWS_REGION)").Envar("SAML2AWS_REGION").Short('r').StringVar(&commonFlags.Region)
 	app.Flag("prompter", "The prompter to use for user input (default, pinentry)").StringVar(&commonFlags.Prompter)
+	app.Flag("kc-broker", "The kc broker to use when authenticating via keycloak").StringVar(&commonFlags.KCBroker)
 
 	// `configure` command and settings
 	cmdConfigure := app.Command("configure", "Configure a new IDP account.")
@@ -190,7 +191,6 @@ func main() {
 	http.DefaultTransport.(*http.Transport).Proxy = http.ProxyFromEnvironment
 
 	logrus.WithField("command", command).Debug("Running")
-
 	var err error
 	switch command {
 	case cmdScript.FullCommand():

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -69,6 +69,7 @@ type IDPAccount struct {
 	Prompter              string `ini:"prompter"`
 	KCAuthErrorMessage    string `ini:"kc_auth_error_message,omitempty"` // used by KeyCloak; hide from user if not set
 	KCAuthErrorElement    string `ini:"kc_auth_error_element,omitempty"` // used by KeyCloak; hide from user if not set
+	KCBroker              string `ini:"kc_broker"`                       // used by KeyCloak;
 }
 
 func (ia IDPAccount) String() string {

--- a/pkg/creds/creds.go
+++ b/pkg/creds/creds.go
@@ -13,4 +13,5 @@ type LoginDetails struct {
 	URL               string
 	StateToken        string // used by Okta
 	OktaSessionCookie string // used by Okta
+	KCBroker          string // used by KeyCloak
 }

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -39,6 +39,7 @@ type CommonFlags struct {
 	DisableRememberDevice bool
 	DisableSessions       bool
 	Prompter              string
+	KCBroker              string
 }
 
 // LoginExecFlags flags for the Login / Exec commands
@@ -147,7 +148,9 @@ func ApplyFlagOverrides(commonFlags *CommonFlags, account *cfg.IDPAccount) {
 	if commonFlags.Prompter != "" {
 		account.Prompter = commonFlags.Prompter
 	}
-
+	if commonFlags.KCBroker != "" {
+		account.KCBroker = commonFlags.KCBroker
+	}
 	// select the prompter
 	if commonFlags.Prompter != "" {
 		account.Prompter = commonFlags.Prompter

--- a/pkg/provider/keycloak/keycloak.go
+++ b/pkg/provider/keycloak/keycloak.go
@@ -96,7 +96,7 @@ func (kc *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 }
 
 func (kc *Client) doAuthenticate(authCtx *authContext, loginDetails *creds.LoginDetails) (string, error) {
-	authSubmitURL, authForm, err := kc.getLoginForm(loginDetails)
+	authSubmitURL, authForm, authCookies, err := kc.getLoginForm(loginDetails)
 	if err != nil {
 		return "", errors.Wrap(err, "error retrieving login form from idp")
 	}
@@ -129,18 +129,16 @@ func (kc *Client) doAuthenticate(authCtx *authContext, loginDetails *creds.Login
 		if err != nil {
 			return "", errors.Wrap(err, "could not extract Webauthn parameters")
 		}
-
 		webauthnSubmitURL, err := extractSubmitURL(doc)
 		if err != nil {
 			return "", errors.Wrap(err, "unable to locate IDP Webauthn form submit URL")
 		}
 
-		doc, err = kc.postWebauthnForm(webauthnSubmitURL, credentialIDs, challenge, rpId)
+		doc, err = kc.postWebauthnForm(webauthnSubmitURL, credentialIDs, challenge, rpId, authCookies)
 		if err != nil {
 			return "", errors.Wrap(err, "error posting Webauthn form")
 		}
 	}
-
 	samlResponse, err := extractSamlResponse(doc)
 	if err != nil && authCtx.authenticatorIndexValid && passwordValid(doc, kc.authErrorValidator) {
 		return kc.doAuthenticate(authCtx, loginDetails)
@@ -185,22 +183,58 @@ func extractWebauthnParameters(doc *goquery.Document) (credentialIDs []string, c
 	return credentialIDs, challenge, rpID, nil
 }
 
-func (kc *Client) getLoginForm(loginDetails *creds.LoginDetails) (string, url.Values, error) {
+func (kc *Client) getLoginForm(loginDetails *creds.LoginDetails) (string, url.Values, []*http.Cookie, error) {
 
 	res, err := kc.client.Get(loginDetails.URL)
+
 	if err != nil {
-		return "", nil, errors.Wrap(err, "error retrieving form")
+		return "", nil, nil, errors.Wrap(err, "error retrieving form")
 	}
 
 	doc, err := goquery.NewDocumentFromReader(res.Body)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "failed to build document from response")
+		return "", nil, nil, errors.Wrap(err, "failed to build document from response")
 	}
 
+	if loginDetails.KCBroker != "" {
+		log.Printf("Attempting to parse federation chain using keycloak broker %v", loginDetails.KCBroker)
+		KCFederationID := "#social-" + loginDetails.KCBroker
+		var path string
+		doc.Find(KCFederationID).Each(func(i int, s *goquery.Selection) {
+			href, ok := s.Attr("href")
+			if !ok {
+				return
+			}
+			path = href
+		})
+		url, err := url.Parse(loginDetails.URL)
+		if err != nil {
+			return "", nil, nil, errors.Wrap(err, "error parsing url for federation")
+		}
+		new_url := "https://" + url.Hostname() + path
+		req, err := http.NewRequest("GET", new_url, nil)
+		if err != nil {
+			return "", nil, nil, errors.Wrap(err, "error building federated request")
+		}
+		for _, cookie := range res.Cookies() {
+			req.AddCookie(cookie)
+			// log.Println("added cookie: %v to request", cookie)
+		}
+		res2, err := kc.client.Get(new_url)
+		if err != nil {
+			return "", nil, nil, errors.Wrap(err, "error retrieving federated form")
+		}
+		doc2, err := goquery.NewDocumentFromReader(res2.Body)
+		if err != nil {
+			return "", nil, nil, errors.Wrap(err, "failed to build federated document from response")
+		}
+		doc = doc2
+		res = res2
+	}
 	if res.StatusCode == http.StatusUnauthorized {
 		authSubmitURL, err := extractSubmitURL(doc)
 		if err != nil {
-			return "", nil, errors.Wrap(err, "unable to locate IDP authentication form submit URL")
+			return "", nil, nil, errors.Wrap(err, "unable to locate IDP authentication form submit URL")
 		}
 		loginDetails.URL = authSubmitURL
 		return kc.getLoginForm(loginDetails)
@@ -211,13 +245,13 @@ func (kc *Client) getLoginForm(loginDetails *creds.LoginDetails) (string, url.Va
 	doc.Find("input").Each(func(i int, s *goquery.Selection) {
 		updateKeyCloakFormData(authForm, s, loginDetails)
 	})
-
+	authCookies := res.Cookies()
 	authSubmitURL, err := extractSubmitURL(doc)
 	if err != nil {
-		return "", nil, errors.Wrap(err, "unable to locate IDP authentication form submit URL")
+		return "", nil, nil, errors.Wrap(err, "unable to locate IDP authentication form submit URL")
 	}
 
-	return authSubmitURL, authForm, nil
+	return authSubmitURL, authForm, authCookies, nil
 }
 
 func (kc *Client) postLoginForm(authSubmitURL string, authForm url.Values) ([]byte, error) {
@@ -279,9 +313,8 @@ func (kc *Client) postTotpForm(authCtx *authContext, totpSubmitURL string, doc *
 	return doc, nil
 }
 
-func (kc *Client) postWebauthnForm(webauthnSubmitURL string, credentialIDs []string, challenge, rpId string) (*goquery.Document, error) {
+func (kc *Client) postWebauthnForm(webauthnSubmitURL string, credentialIDs []string, challenge, rpId string, cookies []*http.Cookie) (*goquery.Document, error) {
 	webauthnForm := url.Values{}
-
 	var assertion *okta.SignedAssertion
 	var pickedCredentialID string
 	for i, credentialID := range credentialIDs {
@@ -326,14 +359,14 @@ func (kc *Client) postWebauthnForm(webauthnSubmitURL string, credentialIDs []str
 	webauthnForm.Set("credentialId", pickedCredentialID)
 	webauthnForm.Set("userHandle", "")
 	webauthnForm.Set("error", "")
-
 	req, err := http.NewRequest("POST", webauthnSubmitURL, strings.NewReader(webauthnForm.Encode()))
 	if err != nil {
 		return nil, errors.Wrap(err, "error building MFA request")
 	}
-
 	req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
+	for _, cookie := range cookies {
+		req.AddCookie(cookie)
+	}
 	res, err := kc.client.Do(req)
 	if err != nil {
 		return nil, errors.Wrap(err, "error retrieving content")
@@ -343,7 +376,6 @@ func (kc *Client) postWebauthnForm(webauthnSubmitURL string, credentialIDs []str
 	if err != nil {
 		return nil, errors.Wrap(err, "error reading webauthn form response")
 	}
-
 	return doc, nil
 }
 
@@ -366,7 +398,6 @@ func extractSubmitURL(doc *goquery.Document) (string, error) {
 		}
 		submitURL = action
 	})
-
 	if submitURL == "" {
 		return "", fmt.Errorf("unable to locate form submit URL")
 	}
@@ -377,7 +408,6 @@ func extractSubmitURL(doc *goquery.Document) (string, error) {
 func extractSamlResponse(doc *goquery.Document) (string, error) {
 	var samlAssertion = ""
 	var err = fmt.Errorf("unable to locate saml response field")
-
 	doc.Find("input").Each(func(i int, s *goquery.Selection) {
 		name, ok := s.Attr("name")
 		if ok && name == "SAMLResponse" {

--- a/pkg/provider/keycloak/keycloak_test.go
+++ b/pkg/provider/keycloak/keycloak_test.go
@@ -36,7 +36,7 @@ func TestClient_getLoginForm(t *testing.T) {
 	kc := Client{client: &provider.HTTPClient{Client: http.Client{}, Options: opts}}
 	loginDetails := &creds.LoginDetails{URL: ts.URL, Username: "test", Password: "test123"}
 
-	submitURL, authForm, err := kc.getLoginForm(loginDetails)
+	submitURL, authForm, authCookies, err := kc.getLoginForm(loginDetails)
 	require.Nil(t, err)
 	require.Equal(t, exampleLoginURL, submitURL)
 	require.Equal(t, url.Values{
@@ -44,6 +44,8 @@ func TestClient_getLoginForm(t *testing.T) {
 		"password": []string{"test123"},
 		"login":    []string{"Log in"},
 	}, authForm)
+	require.Equal(t, []*http.Cookie([]*http.Cookie{}), authCookies)
+
 }
 
 func TestClient_getLoginFormTryAnotherWay(t *testing.T) {
@@ -59,7 +61,7 @@ func TestClient_getLoginFormTryAnotherWay(t *testing.T) {
 	kc := Client{client: &provider.HTTPClient{Client: http.Client{}, Options: opts}}
 	loginDetails := &creds.LoginDetails{URL: ts.URL, Username: "test", Password: "test123"}
 
-	submitURL, authForm, err := kc.getLoginForm(loginDetails)
+	submitURL, authForm, authCookies, err := kc.getLoginForm(loginDetails)
 	require.Nil(t, err)
 	require.Equal(t, exampleLoginURL, submitURL)
 	require.Equal(t, url.Values{
@@ -67,6 +69,7 @@ func TestClient_getLoginFormTryAnotherWay(t *testing.T) {
 		"password": []string{"test123"},
 		"login":    []string{"Log in"},
 	}, authForm)
+	require.Equal(t, []*http.Cookie([]*http.Cookie{}), authCookies)
 }
 
 func TestClient_getLoginFormRedirect(t *testing.T) {
@@ -93,7 +96,7 @@ func TestClient_getLoginFormRedirect(t *testing.T) {
 	kc := Client{client: &provider.HTTPClient{Client: http.Client{}, Options: opts}}
 	loginDetails := &creds.LoginDetails{URL: ts.URL, Username: "test", Password: "test123"}
 
-	submitURL, authForm, err := kc.getLoginForm(loginDetails)
+	submitURL, authForm, authCookies, err := kc.getLoginForm(loginDetails)
 	require.Nil(t, err)
 	require.Equal(t, 2, count)
 	require.Equal(t, exampleLoginURL, submitURL)
@@ -102,6 +105,7 @@ func TestClient_getLoginFormRedirect(t *testing.T) {
 		"password": []string{"test123"},
 		"login":    []string{"Log in"},
 	}, authForm)
+	require.Equal(t, []*http.Cookie([]*http.Cookie{}), authCookies)
 }
 
 func TestClient_postLoginForm(t *testing.T) {


### PR DESCRIPTION
This pull request fixes the issues of saml2aws not having the ability to hop multiple request chains to follow keycloak brokers, as well as the issue of it not carrying cookies along with the requests in this chain, which would result in it failing to do any multi-provider hops. 

I mentioned the issue this is solving in #1395 

After looking at how the keycloak authentication chain operates, I've managed to add a flag called "kc-broker" for logging in. This flag you can give a valid kc-broker name, (specified in your keycloak configuration). Keycloak will then take this broker and follow through to the target broker, beginning the authentication chain. Once this process begins the only necessary component that needed adding to saml2aws was for saml2aws to carry cookies forward along the request chain. 

This avoids the usage of the browser mode, for requests that stay within the keycloak ecosystem, and allows usage of keychain to store credentials for accounts in other federations. 

It passes all tests, and works similar to other flags.  This could likely be expanded to other providers in the case the authentication has to go through several different sources to fully authenticate. 