### PR TITLE
Improve error messages for invalid Keycloak credentials and OTP codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -709,9 +709,11 @@ http_retry_delay        = 1
 region                  = us-east-1
 ```
 
-For KeyCloak, 2 more parameters are available to end a failed authentication process.
+For KeyCloak, 4 more parameters are available to end a failed authentication process.
  - `kc_auth_error_element` - configures what HTTP element saml2aws looks for in authentication error responses. Defaults to "span#input-error" and looks for `<span id=input-error>xxx</span>`. Goquery is used. "span#id-name" looks for `<span id=id-name>xxx</span>`. "span.class-name" looks for `<span class=class-name>xxx</span>`.
  - `kc_auth_error_message` - works with the `kc_auth_error_element` and configures what HTTP message saml2aws looks for in authentication error responses. Defaults to "Invalid username or password." and looks for `<xxx>Invalid username or password.</xxx>`. [Regular expressions](https://github.com/google/re2/wiki/Syntax) are accepted.
+ - `kc_auth_otp_error_element` - works like `kc_auth_error_element` but for otp errors.
+ - `kc_auth_otp_error_message` - works like `kc_auth_error_message` but for otp errors.
 
 Example: If your KeyCloak server returns the authentication error message "Invalid username or password." in a different language in the `<span class=kc-feedback-text>xxx</span>` element, these parameters would look like:
 ```

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -67,11 +67,11 @@ type IDPAccount struct {
 	BrowserDriverDir      string `ini:"browser_driver_dir,omitempty"` // used by browser; hide from user if not set
 	Headless              bool   `ini:"headless"`                     // used by browser
 	Prompter              string `ini:"prompter"`
-	KCAuthErrorMessage    string `ini:"kc_auth_error_message,omitempty"` // used by KeyCloak; hide from user if not set
-	KCAuthErrorElement    string `ini:"kc_auth_error_element,omitempty"` // used by KeyCloak; hide from user if not set
+	KCAuthErrorMessage    string `ini:"kc_auth_error_message,omitempty"`     // used by KeyCloak; hide from user if not set
+	KCAuthErrorElement    string `ini:"kc_auth_error_element,omitempty"`     // used by KeyCloak; hide from user if not set
 	KCAuthOtpErrorMessage string `ini:"kc_auth_otp_error_message,omitempty"` // used by KeyCloak; hide from user if not set
 	KCAuthOtpErrorElement string `ini:"kc_auth_otp_error_element,omitempty"` // used by KeyCloak; hide from user if not set
-	KCBroker              string `ini:"kc_broker"`                       // used by KeyCloak;
+	KCBroker              string `ini:"kc_broker"`                           // used by KeyCloak;
 }
 
 func (ia IDPAccount) String() string {

--- a/pkg/cfg/cfg.go
+++ b/pkg/cfg/cfg.go
@@ -69,6 +69,8 @@ type IDPAccount struct {
 	Prompter              string `ini:"prompter"`
 	KCAuthErrorMessage    string `ini:"kc_auth_error_message,omitempty"` // used by KeyCloak; hide from user if not set
 	KCAuthErrorElement    string `ini:"kc_auth_error_element,omitempty"` // used by KeyCloak; hide from user if not set
+	KCAuthOtpErrorMessage string `ini:"kc_auth_otp_error_message,omitempty"` // used by KeyCloak; hide from user if not set
+	KCAuthOtpErrorElement string `ini:"kc_auth_otp_error_element,omitempty"` // used by KeyCloak; hide from user if not set
 	KCBroker              string `ini:"kc_broker"`                       // used by KeyCloak;
 }
 

--- a/pkg/provider/keycloak/example/authError-Totp-invalidCode-ru-v2.html
+++ b/pkg/provider/keycloak/example/authError-Totp-invalidCode-ru-v2.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html class="login-pf" lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="robots" content="noindex, nofollow">
+  <meta name="color-scheme" content="light dark">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <title>Sign in to internal</title>
+  <link rel="icon" href="/resources/kb6gy/login/keycloak.v2/img/favicon.ico" />
+  <link href="/resources/kb6gy/common/keycloak/vendor/patternfly-v5/patternfly.min.css" rel="stylesheet" />
+  <link href="/resources/kb6gy/common/keycloak/vendor/patternfly-v5/patternfly-addons.css" rel="stylesheet" />
+  <link href="/resources/kb6gy/login/keycloak.v2/css/styles.css" rel="stylesheet" />
+  <script type="importmap">
+    {
+        "imports": {
+            "rfc4648": "/resources/kb6gy/common/keycloak/vendor/rfc4648/rfc4648.js"
+        }
+    }
+  </script>
+  <script type="module" async blocking="render">
+    const DARK_MODE_CLASS = "pf-v5-theme-dark";
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    updateDarkMode(mediaQuery.matches);
+    mediaQuery.addEventListener("change", (event) => updateDarkMode(event.matches));
+
+    function updateDarkMode(isEnabled) {
+      const { classList } = document.documentElement;
+
+      if (isEnabled) {
+        classList.add(DARK_MODE_CLASS);
+      } else {
+        classList.remove(DARK_MODE_CLASS);
+      }
+    }
+  </script>
+  <script type="module" src="/resources/kb6gy/login/keycloak.v2/js/passwordVisibility.js"></script>
+  <script type="module">
+    import { startSessionPolling } from "/resources/kb6gy/login/keycloak.v2/js/authChecker.js";
+
+    startSessionPolling(
+      "/realms/internal/login-actions/restart?client_id=urn%3Aamazon%3Awebservices&tab_id=-qLBcCdOZQk&client_data=&skip_logout=true"
+    );
+  </script>
+  <script type="module">
+    import { checkAuthSession } from "/resources/kb6gy/login/keycloak.v2/js/authChecker.js";
+
+    checkAuthSession(
+      "sessionId"
+    );
+  </script>
+  <script>
+    // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1404468
+    const isFirefox = true;
+  </script>
+  <SCRIPT> if (typeof history.replaceState === 'function') {  history.replaceState({}, "some title", "https://my.domain/realms/internal/login-actions/authenticate?execution=&client_id=urn%3Aamazon%3Awebservices&tab_id=&client_data="); }</SCRIPT></head>
+
+<body id="keycloak-bg" class="">
+<div class="pf-v5-c-login">
+  <div class="pf-v5-c-login__container">
+    <header id="kc-header" class="pf-v5-c-login__header">
+      <div id="kc-header-wrapper"
+           class="pf-v5-c-brand">internal</div>
+    </header>
+    <main class="pf-v5-c-login__main">
+      <div class="pf-v5-c-login__main-header">
+        <h1 class="pf-v5-c-title pf-m-3xl" id="kc-page-title"><!-- template: login-otp.ftl -->
+
+          Sign In
+        </h1>
+      </div>
+      <div class="pf-v5-c-login__main-body">
+        <div class="pf-v5-c-form pf-v5-u-mb-md-on-md">
+          <!-- template: login-otp.ftl -->
+
+
+          <div class="pf-v5-c-form__group">
+            <div class="pf-v5-c-form__label">
+              <label for="username" class="pf-v5-c-form__label">
+        <span class="pf-v5-c-form__label-text">
+                Username or email
+
+        </span>
+              </label>
+            </div>
+
+            <div class="pf-v5-c-input-group">
+              <div class="pf-v5-c-input-group__item pf-m-fill">
+        <span class="pf-v5-c-form-control pf-m-readonly">
+          <input id="kc-attempted-username" value="aorlovskiy" readonly>
+        </span>
+              </div>
+              <div class="pf-v5-c-input-group__item">
+                <button id="reset-login" class="pf-v5-c-button pf-m-control kc-login-tooltip" type="button"
+                        aria-label="Restart login" onclick="location.href='/realms/internal/login-actions/restart?client_id=urn%3Aamazon%3Awebservices&amp;tab_id=&amp;client_data=&amp;skip_logout=false'">
+                  <i class="fa-sync-alt fas" aria-hidden="true"></i>
+                  <span class="kc-tooltip-text">Restart login</span>
+                </button>
+              </div>
+
+              <div id="input-error-container-username">
+              </div>
+            </div>
+
+          </div>
+
+
+          <!-- template: login-otp.ftl -->
+
+          <form id="kc-otp-login-form" class="pf-v5-c-form" onsubmit="login.disabled = true; return true;" action="https://c/realms/internal/login-actions/authenticate?session_code=&amp;execution=&amp;client_id=urn%3Aamazon%3Awebservices&amp;tab_id=&amp;client_data=" method="post">
+            <input id="selectedCredentialId" type="hidden" name="selectedCredentialId" value="3f3712fe-7e9a-46ba-9944-18d1cebe4a46">
+
+
+            <div class="pf-v5-c-form__group">
+              <div class="pf-v5-c-form__label">
+                <label for="otp" class="pf-v5-c-form__label">
+        <span class="pf-v5-c-form__label-text">
+            One-time code
+        </span>
+                </label>
+              </div>
+
+              <span class="pf-v5-c-form-control pf-m-error">
+        <input id="otp" name="otp" value="" type="text" autocomplete="one-time-code" autofocus
+               aria-invalid="true"/>
+    <span class="pf-v5-c-form-control__utilities">
+        <span class="pf-v5-c-form-control__icon pf-m-status">
+          <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+        </span>
+    </span>
+    </span>
+
+              <div id="input-error-container-otp">
+                <div class="pf-v5-c-form__helper-text" aria-live="polite">
+                  <div class="pf-v5-c-helper-text">
+                    <div class="pf-v5-c-helper-text__item pf-m-error" id="input-error-otp">
+                        <span class="pf-v5-c-helper-text__item-text pf-m-error kc-feedback-text">
+                            Неправильный код аутентификации.
+                        </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+
+            <div class="pf-v5-c-form__group">
+              <div class="pf-v5-c-form__actions">
+                <button class="pf-v5-c-button pf-m-primary pf-m-block " name="login" id="kc-login" type="submit">Sign In</button>
+              </div>
+            </div>
+          </form>
+          <script>
+            function toggleOTP(index, value) {
+              // select the clicked OTP credential
+              document.getElementById("selectedCredentialId").value = value;
+              // remove selected class from all OTP credentials
+              Array.from(document.getElementsByClassName("pf-m-selected")).map(i => i.classList.remove("pf-m-selected"));
+              // add selected class to the clicked OTP credential
+              document.getElementById("kc-otp-credential-" + index).classList.add("pf-m-selected");
+            }
+          </script>
+
+          <form id="kc-select-try-another-way-form" action="https://my.domain/realms/internal/login-actions/authenticate?session_code=&amp;execution=&amp;client_id=urn%3Aamazon%3Awebservices&amp;tab_id=&amp;client_data=" method="post" novalidate="novalidate">
+            <input type="hidden" name="tryAnotherWay" value="on"/>
+            <a id="try-another-way" href="javascript:document.forms['kc-select-try-another-way-form'].requestSubmit()"
+               class="pf-v5-c-button pf-m-secondary pf-m-block pf-v5-u-mt-md-on-md">
+              Try Another Way
+            </a>
+          </form>
+
+        </div>
+        <div class="pf-v5-c-login__main-footer">
+          <!-- template: login-otp.ftl -->
+
+        </div>
+    </main>
+
+  </div>
+</div>
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'91c8c6eefab6d2f2',t:'MTc0MTMzNjcxMS4wMDAwMDA='};var a=document.createElement('script');a.nonce='';a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/pkg/provider/keycloak/example/authError-Totp-invalidCode-v2.html
+++ b/pkg/provider/keycloak/example/authError-Totp-invalidCode-v2.html
@@ -1,0 +1,185 @@
+<!DOCTYPE html>
+<html class="login-pf" lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="robots" content="noindex, nofollow">
+  <meta name="color-scheme" content="light dark">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+
+  <title>Sign in to internal</title>
+  <link rel="icon" href="/resources/kb6gy/login/keycloak.v2/img/favicon.ico" />
+  <link href="/resources/kb6gy/common/keycloak/vendor/patternfly-v5/patternfly.min.css" rel="stylesheet" />
+  <link href="/resources/kb6gy/common/keycloak/vendor/patternfly-v5/patternfly-addons.css" rel="stylesheet" />
+  <link href="/resources/kb6gy/login/keycloak.v2/css/styles.css" rel="stylesheet" />
+  <script type="importmap">
+    {
+        "imports": {
+            "rfc4648": "/resources/kb6gy/common/keycloak/vendor/rfc4648/rfc4648.js"
+        }
+    }
+  </script>
+  <script type="module" async blocking="render">
+    const DARK_MODE_CLASS = "pf-v5-theme-dark";
+    const mediaQuery = window.matchMedia("(prefers-color-scheme: dark)");
+
+    updateDarkMode(mediaQuery.matches);
+    mediaQuery.addEventListener("change", (event) => updateDarkMode(event.matches));
+
+    function updateDarkMode(isEnabled) {
+      const { classList } = document.documentElement;
+
+      if (isEnabled) {
+        classList.add(DARK_MODE_CLASS);
+      } else {
+        classList.remove(DARK_MODE_CLASS);
+      }
+    }
+  </script>
+  <script type="module" src="/resources/kb6gy/login/keycloak.v2/js/passwordVisibility.js"></script>
+  <script type="module">
+    import { startSessionPolling } from "/resources/kb6gy/login/keycloak.v2/js/authChecker.js";
+
+    startSessionPolling(
+      "/realms/internal/login-actions/restart?client_id=urn%3Aamazon%3Awebservices&tab_id=-qLBcCdOZQk&client_data=&skip_logout=true"
+    );
+  </script>
+  <script type="module">
+    import { checkAuthSession } from "/resources/kb6gy/login/keycloak.v2/js/authChecker.js";
+
+    checkAuthSession(
+      "sessionId"
+    );
+  </script>
+  <script>
+    // Workaround for https://bugzilla.mozilla.org/show_bug.cgi?id=1404468
+    const isFirefox = true;
+  </script>
+  <SCRIPT> if (typeof history.replaceState === 'function') {  history.replaceState({}, "some title", "https://my.domain/realms/internal/login-actions/authenticate?execution=&client_id=urn%3Aamazon%3Awebservices&tab_id=&client_data="); }</SCRIPT></head>
+
+<body id="keycloak-bg" class="">
+<div class="pf-v5-c-login">
+  <div class="pf-v5-c-login__container">
+    <header id="kc-header" class="pf-v5-c-login__header">
+      <div id="kc-header-wrapper"
+           class="pf-v5-c-brand">internal</div>
+    </header>
+    <main class="pf-v5-c-login__main">
+      <div class="pf-v5-c-login__main-header">
+        <h1 class="pf-v5-c-title pf-m-3xl" id="kc-page-title"><!-- template: login-otp.ftl -->
+
+          Sign In
+        </h1>
+      </div>
+      <div class="pf-v5-c-login__main-body">
+        <div class="pf-v5-c-form pf-v5-u-mb-md-on-md">
+          <!-- template: login-otp.ftl -->
+
+
+          <div class="pf-v5-c-form__group">
+            <div class="pf-v5-c-form__label">
+              <label for="username" class="pf-v5-c-form__label">
+        <span class="pf-v5-c-form__label-text">
+                Username or email
+
+        </span>
+              </label>
+            </div>
+
+            <div class="pf-v5-c-input-group">
+              <div class="pf-v5-c-input-group__item pf-m-fill">
+        <span class="pf-v5-c-form-control pf-m-readonly">
+          <input id="kc-attempted-username" value="aorlovskiy" readonly>
+        </span>
+              </div>
+              <div class="pf-v5-c-input-group__item">
+                <button id="reset-login" class="pf-v5-c-button pf-m-control kc-login-tooltip" type="button"
+                        aria-label="Restart login" onclick="location.href='/realms/internal/login-actions/restart?client_id=urn%3Aamazon%3Awebservices&amp;tab_id=&amp;client_data=&amp;skip_logout=false'">
+                  <i class="fa-sync-alt fas" aria-hidden="true"></i>
+                  <span class="kc-tooltip-text">Restart login</span>
+                </button>
+              </div>
+
+              <div id="input-error-container-username">
+              </div>
+            </div>
+
+          </div>
+
+
+          <!-- template: login-otp.ftl -->
+
+          <form id="kc-otp-login-form" class="pf-v5-c-form" onsubmit="login.disabled = true; return true;" action="https://c/realms/internal/login-actions/authenticate?session_code=&amp;execution=&amp;client_id=urn%3Aamazon%3Awebservices&amp;tab_id=&amp;client_data=" method="post">
+            <input id="selectedCredentialId" type="hidden" name="selectedCredentialId" value="3f3712fe-7e9a-46ba-9944-18d1cebe4a46">
+
+
+            <div class="pf-v5-c-form__group">
+              <div class="pf-v5-c-form__label">
+                <label for="otp" class="pf-v5-c-form__label">
+        <span class="pf-v5-c-form__label-text">
+            One-time code
+        </span>
+                </label>
+              </div>
+
+              <span class="pf-v5-c-form-control pf-m-error">
+        <input id="otp" name="otp" value="" type="text" autocomplete="one-time-code" autofocus
+               aria-invalid="true"/>
+    <span class="pf-v5-c-form-control__utilities">
+        <span class="pf-v5-c-form-control__icon pf-m-status">
+          <i class="fas fa-exclamation-circle" aria-hidden="true"></i>
+        </span>
+    </span>
+    </span>
+
+              <div id="input-error-container-otp">
+                <div class="pf-v5-c-form__helper-text" aria-live="polite">
+                  <div class="pf-v5-c-helper-text">
+                    <div class="pf-v5-c-helper-text__item pf-m-error" id="input-error-otp">
+                        <span class="pf-v5-c-helper-text__item-text pf-m-error kc-feedback-text">
+                            Invalid authenticator code.
+                        </span>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            </div>
+
+
+            <div class="pf-v5-c-form__group">
+              <div class="pf-v5-c-form__actions">
+                <button class="pf-v5-c-button pf-m-primary pf-m-block " name="login" id="kc-login" type="submit">Sign In</button>
+              </div>
+            </div>
+          </form>
+          <script>
+            function toggleOTP(index, value) {
+              // select the clicked OTP credential
+              document.getElementById("selectedCredentialId").value = value;
+              // remove selected class from all OTP credentials
+              Array.from(document.getElementsByClassName("pf-m-selected")).map(i => i.classList.remove("pf-m-selected"));
+              // add selected class to the clicked OTP credential
+              document.getElementById("kc-otp-credential-" + index).classList.add("pf-m-selected");
+            }
+          </script>
+
+          <form id="kc-select-try-another-way-form" action="https://my.domain/realms/internal/login-actions/authenticate?session_code=&amp;execution=&amp;client_id=urn%3Aamazon%3Awebservices&amp;tab_id=&amp;client_data=" method="post" novalidate="novalidate">
+            <input type="hidden" name="tryAnotherWay" value="on"/>
+            <a id="try-another-way" href="javascript:document.forms['kc-select-try-another-way-form'].requestSubmit()"
+               class="pf-v5-c-button pf-m-secondary pf-m-block pf-v5-u-mt-md-on-md">
+              Try Another Way
+            </a>
+          </form>
+
+        </div>
+        <div class="pf-v5-c-login__main-footer">
+          <!-- template: login-otp.ftl -->
+
+        </div>
+    </main>
+
+  </div>
+</div>
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'91c8c6eefab6d2f2',t:'MTc0MTMzNjcxMS4wMDAwMDA='};var a=document.createElement('script');a.nonce='';a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/pkg/provider/keycloak/example/authError-Totp-invalidCode.html
+++ b/pkg/provider/keycloak/example/authError-Totp-invalidCode.html
@@ -1,0 +1,112 @@
+<!DOCTYPE html>
+<html class="login-pf" lang="en">
+
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+  <meta name="robots" content="noindex, nofollow">
+
+  <meta name="viewport" content="width=device-width,initial-scale=1"/>
+  <title>Sign in to internal</title>
+  <link rel="icon" href="/resources/kb6gy/login/keycloak/img/favicon.ico" />
+  <link href="/resources/kb6gy/common/keycloak/vendor/patternfly-v4/patternfly.min.css" rel="stylesheet" />
+  <link href="/resources/kb6gy/common/keycloak/vendor/patternfly-v3/css/patternfly.min.css" rel="stylesheet" />
+  <link href="/resources/kb6gy/common/keycloak/vendor/patternfly-v3/css/patternfly-additions.min.css" rel="stylesheet" />
+  <link href="/resources/kb6gy/common/keycloak/lib/pficon/pficon.css" rel="stylesheet" />
+  <link href="/resources/kb6gy/login/keycloak/css/login.css" rel="stylesheet" />
+  <script type="importmap">
+    {
+        "imports": {
+            "rfc4648": "/resources/kb6gy/common/keycloak/vendor/rfc4648/rfc4648.js"
+        }
+    }
+  </script>
+  <script src="/resources/kb6gy/login/keycloak/js/menu-button-links.js" type="module"></script>
+  <script type="module">
+    import { startSessionPolling } from "/resources/kb6gy/login/keycloak/js/authChecker.js";
+
+    startSessionPolling(
+      "/realms/internal/login-actions/restart?client_id=urn%3Aamazon%3Awebservices&tab_id=&client_data=&skip_logout=true"
+    );
+  </script>
+  <script type="module">
+    import { checkAuthSession } from "/resources/kb6gy/login/keycloak/js/authChecker.js";
+
+    checkAuthSession(
+      "sessionValue"
+    );
+  </script>
+  <SCRIPT> if (typeof history.replaceState === 'function') {  history.replaceState({}, "some title", "https://my.domain/realms/internal/login-actions/authenticate?execution=&client_id=urn%3Aamazon%3Awebservices&tab_id=&client_data="); }</SCRIPT></head>
+
+<body class="">
+<div class="login-pf-page">
+  <div id="kc-header" class="login-pf-page-header">
+    <div id="kc-header-wrapper"
+         class="">internal</div>
+  </div>
+  <div class="card-pf">
+    <header class="login-pf-header">
+      <div id="kc-username" class="form-group">
+        <label id="kc-attempted-username">aorlovskiy</label>
+        <a id="reset-login" href="/realms/internal/login-actions/restart?client_id=urn%3Aamazon%3Awebservices&amp;tab_id=&amp;client_data=&amp;skip_logout=false" aria-label="Restart login">
+          <div class="kc-login-tooltip">
+            <i class="pficon pficon-arrow fa"></i>
+            <span class="kc-tooltip-text">Restart login</span>
+          </div>
+        </a>
+      </div>
+    </header>
+    <div id="kc-content">
+      <div id="kc-content-wrapper">
+
+
+        <form id="kc-otp-login-form" class="form-horizontal" onsubmit="login.disabled = true; return true;" action="https://my.domain/realms/internal/login-actions/authenticate?session_code=&amp;execution=&amp;client_id=urn%3Aamazon%3Awebservices&amp;tab_id=&amp;client_data="
+              method="post">
+
+          <div class="form-group">
+            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+              <label for="otp" class="pf-c-form__label pf-c-form__label-text">One-time code</label>
+            </div>
+
+            <div class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+              <input id="otp" name="otp" autocomplete="one-time-code" type="text" class="pf-c-form-control"
+                     autofocus aria-invalid="true"
+                     dir="ltr" />
+
+              <span id="input-error-otp-code" class="pf-c-form__helper-text pf-m-error required kc-feedback-text"
+                    aria-live="polite">
+                        Invalid authenticator code.
+                    </span>
+            </div>
+          </div>
+
+          <div class="form-group">
+            <div id="kc-form-options" class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+              <div class="">
+              </div>
+            </div>
+
+            <div id="kc-form-buttons" class="col-xs-12 col-sm-12 col-md-12 col-lg-12">
+              <input
+                class="pf-c-button pf-m-primary pf-m-block btn-lg"
+                name="login" id="kc-login" type="submit" value="Sign In" />
+            </div>
+          </div>
+        </form>
+
+        <form id="kc-select-try-another-way-form" action="https://my.domain/realms/internal/login-actions/authenticate?session_code=&amp;execution=&amp;client_id=urn%3Aamazon%3Awebservices&amp;tab_id=&amp;client_data=" method="post">
+          <div class="form-group">
+            <input type="hidden" name="tryAnotherWay" value="on"/>
+            <a href="#" id="try-another-way"
+               onclick="document.forms['kc-select-try-another-way-form'].requestSubmit();return false;">Try Another Way</a>
+          </div>
+        </form>
+
+
+      </div>
+    </div>
+
+  </div>
+</div>
+<script>(function(){function c(){var b=a.contentDocument||a.contentWindow.document;if(b){var d=b.createElement('script');d.innerHTML="window.__CF$cv$params={r:'',t:''};var a=document.createElement('script');a.nonce='';a.src='/cdn-cgi/challenge-platform/scripts/jsd/main.js';document.getElementsByTagName('head')[0].appendChild(a);";b.getElementsByTagName('head')[0].appendChild(d)}}if(document.body){var a=document.createElement('iframe');a.height=1;a.width=1;a.style.position='absolute';a.style.top=0;a.style.left=0;a.style.border='none';a.style.visibility='hidden';document.body.appendChild(a);if('loading'!==document.readyState)c();else if(window.addEventListener)document.addEventListener('DOMContentLoaded',c);else{var e=document.onreadystatechange||function(){};document.onreadystatechange=function(b){e(b);'loading'!==document.readyState&&(document.onreadystatechange=e,c())}}}})();</script></body>
+</html>

--- a/pkg/provider/keycloak/keycloak.go
+++ b/pkg/provider/keycloak/keycloak.go
@@ -142,7 +142,10 @@ func (kc *Client) doAuthenticate(authCtx *authContext, loginDetails *creds.Login
 		}
 	}
 	samlResponse, err := extractSamlResponse(doc)
-	if err != nil && authCtx.authenticatorIndexValid && passwordValid(doc, kc.authErrorValidator) {
+	if err != nil && !passwordValid(doc, kc.authErrorValidator) {
+		return "", fmt.Errorf("%s", DefaultAuthErrorMessage)
+	}
+	if err != nil && authCtx.authenticatorIndexValid {
 		return kc.doAuthenticate(authCtx, loginDetails)
 	}
 	return samlResponse, err

--- a/pkg/provider/keycloak/keycloak.go
+++ b/pkg/provider/keycloak/keycloak.go
@@ -28,8 +28,9 @@ var logger = logrus.WithField("provider", "Keycloak")
 type Client struct {
 	provider.ValidateBase
 
-	client             *provider.HTTPClient
-	authErrorValidator *authErrorValidator
+	client                *provider.HTTPClient
+	authErrorValidator    *authErrorValidator
+	authOtpErrorValidator *authOtpErrorValidator
 }
 
 var (
@@ -60,14 +61,20 @@ func New(idpAccount *cfg.IDPAccount) (*Client, error) {
 		return nil, errors.Wrap(err, "error building http client")
 	}
 
-	authErrorValidator, err := CustomizeAuthErrorValidator(idpAccount)
+	authErrValidator, err := CustomizeAuthErrorValidator(idpAccount)
 	if err != nil {
 		return nil, errors.Wrap(err, "error customizing auth error validator")
 	}
 
+	otpErrValidator, err := CustomizeAuthOtpErrorValidator(idpAccount)
+	if err != nil {
+		return nil, errors.Wrap(err, "error customizing auth otp error validator")
+	}
+
 	return &Client{
-		client:             client,
-		authErrorValidator: authErrorValidator,
+		client:                client,
+		authErrorValidator:    authErrValidator,
+		authOtpErrorValidator: otpErrValidator,
 	}, nil
 }
 
@@ -125,6 +132,9 @@ func (kc *Client) doAuthenticate(authCtx *authContext, loginDetails *creds.Login
 		doc, err = kc.postTotpForm(authCtx, totpSubmitURL, doc)
 		if err != nil {
 			return "", errors.Wrap(err, "error posting totp form")
+		}
+		if kc.authOtpErrorValidator.isCodeInvalid(doc) {
+			return "", fmt.Errorf("otp code is invalid")
 		}
 	} else if containsWebauthnForm(doc) {
 		credentialIDs, challenge, rpId, err := extractWebauthnParameters(doc)

--- a/pkg/provider/keycloak/otp_validator.go
+++ b/pkg/provider/keycloak/otp_validator.go
@@ -1,0 +1,58 @@
+package keycloak
+
+import (
+	"fmt"
+	"regexp"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/pkg/errors"
+	"github.com/versent/saml2aws/v2/pkg/cfg"
+)
+
+var (
+	defaultAuthOtpErrorElementV1 = "span#input-error-otp-code"
+	defaultAuthOtpErrorElementV2 = "div#input-error-container-otp"
+	DefaultAuthOtpErrorElement   = fmt.Sprintf("%s, %s", defaultAuthOtpErrorElementV1, defaultAuthOtpErrorElementV2)
+	DefaultAuthOtpErrorMessage   = "Invalid authenticator code"
+)
+
+type authOtpErrorValidator struct {
+	httpMessageRE *regexp.Regexp
+	httpElement   string
+}
+
+func (v *authOtpErrorValidator) isCodeInvalid(doc *goquery.Document) bool {
+	if v == nil {
+		return false
+	}
+	var invalid = false
+	doc.Find(v.httpElement).Each(func(i int, s *goquery.Selection) {
+		text := s.Text()
+		if v.httpMessageRE.MatchString(text) {
+			invalid = true
+			return
+		}
+	})
+	return invalid
+}
+
+func CustomizeAuthOtpErrorValidator(account *cfg.IDPAccount) (*authOtpErrorValidator, error) {
+	v := &authOtpErrorValidator{
+		httpElement: DefaultAuthOtpErrorElement,
+	}
+	if account.KCAuthOtpErrorElement != "" {
+		v.httpElement = account.KCAuthOtpErrorElement
+	}
+
+	message := DefaultAuthOtpErrorMessage
+	if account.KCAuthOtpErrorMessage != "" {
+		message = account.KCAuthOtpErrorMessage
+	}
+	var err error
+	v.httpMessageRE, err = regexp.Compile(message)
+	if err != nil {
+		return nil, errors.Wrap(err, "could not compile regular expression")
+	}
+
+	return v, nil
+}

--- a/pkg/provider/keycloak/otp_validator_test.go
+++ b/pkg/provider/keycloak/otp_validator_test.go
@@ -1,0 +1,58 @@
+package keycloak
+
+import (
+	"bytes"
+	"os"
+	"testing"
+
+	"github.com/PuerkitoBio/goquery"
+	"github.com/stretchr/testify/require"
+	"github.com/versent/saml2aws/v2/pkg/cfg"
+)
+
+func TestClient_codeInvalid_OtpValidator(t *testing.T) {
+	// Test with the default auth error message and the default HTTP element
+	idpAccount := cfg.IDPAccount{
+		KCAuthOtpErrorMessage: "",
+		KCAuthOtpErrorElement: "",
+	}
+	otpErrValidator, err := CustomizeAuthOtpErrorValidator(&idpAccount)
+	require.Nil(t, err)
+
+	tCases := []struct {
+		name string
+		file string
+	}{
+		{name: "v1", file: "example/authError-Totp-invalidCode.html"},
+		{name: "v2", file: "example/authError-Totp-invalidCode-v2.html"},
+	}
+
+	for _, tc := range tCases {
+		t.Run(tc.name, func(t *testing.T) {
+			data, err := os.ReadFile(tc.file)
+			require.Nil(t, err)
+
+			doc, err := goquery.NewDocumentFromReader(bytes.NewReader(data))
+			require.Nil(t, err)
+
+			require.True(t, otpErrValidator.isCodeInvalid(doc))
+		})
+	}
+}
+
+func TestClient_codeInvalid_OtpValidator_CustomMessage(t *testing.T) {
+	// Test with multiple auth error messages and the default HTTP element
+	idpAccount := cfg.IDPAccount{
+		KCAuthOtpErrorMessage: "Неправильный код",
+	}
+	otpErrValidator, err := CustomizeAuthOtpErrorValidator(&idpAccount)
+	require.Nil(t, err)
+
+	// Test with "Invalid username or password."
+	data, err := os.ReadFile("example/authError-Totp-invalidCode-ru-v2.html")
+	require.Nil(t, err)
+
+	doc, err := goquery.NewDocumentFromReader(bytes.NewReader(data))
+	require.Nil(t, err)
+	require.True(t, otpErrValidator.isCodeInvalid(doc))
+}


### PR DESCRIPTION
prints:
- 'Invalid username or password.' instead of 'unable to locate saml response field' in case of password valiadation failed
- 'otp code is invalid'  instead of 'unable to locate saml response field' in case of otp code is invalid
