### PR TITLE
fix: 🐛 improve password confirmation prompt (fixes #1390)

### DIFF
--- a/cmd/saml2aws/commands/console.go
+++ b/cmd/saml2aws/commands/console.go
@@ -48,9 +48,6 @@ func Console(consoleFlags *flags.ConsoleFlags) error {
 		return errors.Wrap(err,
 			fmt.Sprintf("error loading credentials for profile: %s", consoleFlags.LoginExecFlags.ExecProfile))
 	}
-	if err != nil {
-		return errors.Wrap(err, "error logging in")
-	}
 
 	if consoleFlags.LoginExecFlags.ExecProfile != "" {
 		// Assume the desired role before generating env vars


### PR DESCRIPTION
Prior to this change:
- The saml2aws configure command included a password repeater for confirmation, which was unnecessary as this process is not a sign-up flow. If users entered an incorrect password, they could simply re-initiate the configuration process. The password repeater also caused ambiguity when passwords did not match, leading to a poor user experience.
- The console.go file contained a redundant error check for the err variable, which added unnecessary complexity to the code.


After this change:

- The password repeater has been removed entirely from the saml2aws configure command. This simplifies the flow and eliminates the ambiguity caused by the repeater. If users enter an incorrect password, they can now restart the configuration process without confusion.
- The redundant error check in console.go has been removed, simplifying the code and improving its readability.

fixes #1390 