### PR TITLE
Add authenticator support authentik

### DIFF
--- a/pkg/provider/authentik/authentik.go
+++ b/pkg/provider/authentik/authentik.go
@@ -215,11 +215,14 @@ func getLoginJSON(loginDetails *creds.LoginDetails, payload *authentikPayload) (
 	switch component {
 	case "ak-stage-identification":
 		m["uid_field"] = loginDetails.Username
-		if payload.HasPassowrdField {
+		if payload.HasPasswordField {
 			m["password"] = loginDetails.Password
 		}
 	case "ak-stage-password":
 		m["password"] = loginDetails.Password
+
+	case "ak-stage-authenticator-validate":
+		m["code"] = loginDetails.MFAToken
 	default:
 		return []byte(""), errors.New("unknown component: " + component)
 	}
@@ -259,6 +262,9 @@ func prepareErrors(component string, errs map[string][]map[string]string) string
 	key := "non_field_errors"
 	if field == "password" {
 		key = "password"
+	}
+	if field == "authenticator-validate" {
+		key = "code"
 	}
 	msgs := make([]string, 0, len(errs[key]))
 	for _, err := range errs[key] {

--- a/pkg/provider/authentik/authentik_test.go
+++ b/pkg/provider/authentik/authentik_test.go
@@ -358,7 +358,7 @@ func Test_authWithCombinedUsernamePassword(t *testing.T) {
 }
 
 // Test_authWithCombinedUsernamePasswordAuthenticator
-func Test_authWithCombinedUsernamePassword(t *testing.T) {
+func Test_authWithCombinedUsernamePasswordAuthenticator(t *testing.T) {
 	defer gock.Off()
 	samlResponse := "PHNhbWxwOlJlc3BvbnNlIHhtbG5zOnNhbWxwPSJ1cm46b2FzaX"
 	gock.New("http://127.0.0.1").

--- a/pkg/provider/authentik/authentik_test.go
+++ b/pkg/provider/authentik/authentik_test.go
@@ -357,6 +357,115 @@ func Test_authWithCombinedUsernamePassword(t *testing.T) {
 	assert.Equal(result, samlResponse)
 }
 
+// Test_authWithCombinedUsernamePasswordAuthenticator
+func Test_authWithCombinedUsernamePassword(t *testing.T) {
+	defer gock.Off()
+	samlResponse := "PHNhbWxwOlJlc3BvbnNlIHhtbG5zOnNhbWxwPSJ1cm46b2FzaX"
+	gock.New("http://127.0.0.1").
+		Get("/application/saml/aws/sso/binding/init").
+		Reply(302).
+		SetHeader("Set-Cookie", "[authentik_session=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzaWQiOiJ6cHI3NGdzMjNnOGNqbmF1bXNheGQ1dXVrc2VtZGZpNyIsImlzcyI6ImF1dGhlbnRpayIsInN1YiI6ImFub255bW91cyIsImF1dGhlbnRpY2F0ZWQiOmZhbHNlLCJhY3IiOiJnb2F1dGhlbnRpay5pby9jb3JlL2RlZmF1bHQifQ.zNiX4pk6G9ABeDip0PLs8-0irm2aQ_Arr_RgTxTGCQM; HttpOnly; Path=/; SameSite=None; Secure]").
+		SetHeader("Location", "/flows/-/default/authentication/?next=/application/saml/aws/sso/binding/init/")
+
+	gock.New("http://127.0.0.1").
+		Get("/flows/-/default/authentication").
+		Reply(302).
+		SetHeader("Location", "/if/flow/default-authentication-flow/?next=%2Fapplication%2Fsaml%2Faws%2Fsso%2Fbinding%2Finit%2F")
+
+	gock.New("http://127.0.0.1").
+		Get("/if/flow/default-authentication-flow").
+		Reply(200).
+		BodyString("")
+
+	gock.New("http://127.0.0.1").
+		Get("/api/v3/flows/executor/default-authentication-flow").
+		Reply(200).
+		JSON(map[string]interface{}{
+			"type":               "native",
+			"flow_info":          map[string]interface{}{"title": "Welcome to authentik!", "background": "/static/dist/assets/images/flow_background.jpg", "cancel_url": "/flows/-/cancel/", "layout": "stacked"},
+			"component":          "ak-stage-identification",
+			"user_fields":        []string{"username", "email"},
+			"password_fields":    true,
+			"application_pre":    "aws",
+			"primary_action":     "Log in",
+			"sources":            []string{},
+			"show_source_labels": false,
+		})
+
+	gock.New("http://127.0.0.1").
+		Post("/api/v3/flows/executor/default-authentication-flow").
+		Reply(302).
+		SetHeader("Location", "/api/v3/flows/executor/default-authentication-flow/?query=next%3D%252F")
+
+	gock.New("http://127.0.0.1").
+		Get("api/v3/flows/executor/default-authentication-flow").
+		Reply(200).
+		JSON(map[string]interface{}{
+			"type":                "native",
+			"flow_info":           map[string]interface{}{"title": "Welcome to authentik!", "background": "/static/dist/assets/images/flow_background.jpg", "cancel_url": "/flows/-/cancel/", "layout": "stacked"},
+			"component":           "ak-stage-password",
+			"pending_user":        "user",
+			"pending_user_avatar": "https://secure.gravatar.com/avatar/0932141298741243?s=158&amp;r=g",
+		})
+	gock.New("http://127.0.0.1").
+		Post("/api/v3/flows/executor/default-authentication-flow").
+		Reply(302).
+		SetHeader("Location", "/api/v3/flows/executor/default-authentication-flow/?query=next%3D%252F")
+
+	gock.New("http://127.0.0.1").
+		Get("/api/v3/flows/executor/default-authentication-flow").
+		Reply(302).
+		SetHeader("Location", "/api/v3/flows/executor/default-authentication-flow/?query=next%3D%252F")
+
+	gock.New("http://127.0.0.1").
+		Get("/api/v3/flows/executor/default-authentication-flow").
+		Reply(200).
+		JSON(map[string]interface{}{
+			"type": "redirect",
+			"to":   "http://127.0.0.1/application/saml/aws/sso/binding/init",
+		})
+
+	gock.New("http://127.0.0.1").
+		Get("/application/saml/aws/sso/binding/init").
+		Reply(302).
+		SetHeader("Location", "/if/flow/default-provider-authorization-implicit-consent/")
+
+	gock.New("http://127.0.0.1").
+		Get("/if/flow/default-provider-authorization-implicit-consent/").
+		Reply(200)
+
+	gock.New("http://127.0.0.1").
+		Get("/api/v3/flows").
+		Reply(200).
+		JSON(map[string]interface{}{
+			"type": "native",
+			"flow_info": map[string]interface{}{
+				"title":      "Redirecting to aws",
+				"background": "/static/dist/assets/images/flow_background.jpg",
+				"cancel_url": "/flows/-/cancel/",
+				"layout":     "stacked",
+			},
+			"component": "ak-stage-autosubmit",
+			"url":       "https://signin.amazonaws.com/saml",
+			"attrs": map[string]interface{}{
+				"ACSUrl":       "https://signin.amazonaws.com/saml",
+				"SAMLResponse": samlResponse,
+			},
+		})
+	client, _ := New(&cfg.IDPAccount{})
+	loginDetails := &creds.LoginDetails{
+		Username: "user",
+		Password: "pwd",
+		URL:      "http://127.0.0.1/application/saml/aws/sso/binding/init",
+	}
+	gock.InterceptClient(&client.client.Client)
+	result, err := client.Authenticate(loginDetails)
+
+	assert := assert.New(t)
+	assert.Nil(err)
+	assert.Equal(result, samlResponse)
+}
+
 // Test_simplifiedFlowAuthWithSeperatedUsernamePassword Password only if username/email verified
 func Test_simplifiedFlowAuthWithSeperatedUsernamePassword(t *testing.T) {
 	defer gock.Off()

--- a/pkg/provider/authentik/model.go
+++ b/pkg/provider/authentik/model.go
@@ -19,7 +19,7 @@ type authentikPayload struct {
 	Attrs            map[string]string
 	Component        string
 	Type             string
-	HasPassowrdField bool                           `json:"password_fields"`
+	HasPasswordField bool                           `json:"password_fields"`
 	RedirectTo       string                         `json:"to"`
 	Errors           map[string][]map[string]string `json:"response_errors"`
 }


### PR DESCRIPTION
# What
Adding support for optional usage of MFA authenticator for IdP Authentik

# Why
Without this it is not possible to use authentik provider when MFA like TOTP is configured for a user. Without this added support the only workaround is to use `browser`.
