### PR TITLE
fix(browser): create storageState dir if missing

### DIFF
--- a/pkg/provider/browser/browser.go
+++ b/pkg/provider/browser/browser.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"path/filepath"
 	"regexp"
 	"strings"
 
@@ -136,6 +137,9 @@ func (cl *Client) Authenticate(loginDetails *creds.LoginDetails) (string, error)
 
 	defer func() {
 		logger.Info("saving storage state")
+		if err := os.MkdirAll(filepath.Dir(storageStatePath), 0700); err != nil {
+			logger.Info("Error creating saml2aws directory", err)
+		}
 		_, err := context.StorageState(storageStatePath)
 		if err != nil {
 			logger.Info("Error saving storage state", err)


### PR DESCRIPTION
## What

`context.StorageState()` silently fails when `~/.aws/saml2aws/` doesn't exist, so the Playwright session is never persisted and users are forced to re-authenticate on every `saml2aws login`. Adds an `os.MkdirAll` call before the write so the directory is always created on first run.

## Why

Fresh installs never have `~/.aws/saml2aws/` — nothing in the setup flow creates it. The failure is logged at `INFO` level and swallowed, so users never know session persistence is broken.

## Changes

- `pkg/provider/browser/browser.go`: add `os.MkdirAll(filepath.Dir(storageStatePath), 0700)` before `context.StorageState()` in the defer block; add `path/filepath` import.

Closes: #1526