### PR TITLE
feat: add JSON output for AWS accounts

### DIFF
--- a/aws_account.go
+++ b/aws_account.go
@@ -6,15 +6,24 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"regexp"
 
 	"github.com/PuerkitoBio/goquery"
 	"github.com/pkg/errors"
 )
 
+// accountNameRe matches "Account: alias (123456789012)" capturing alias and number.
+var accountNameRe = regexp.MustCompile(`^Account: (.+) \((\d+)\)$`)
+
+// accountNumberRe matches "Account: 123456789012" capturing just the number.
+var accountNumberRe = regexp.MustCompile(`^Account: (\d+)$`)
+
 // AWSAccount holds the AWS account name and roles
 type AWSAccount struct {
-	Name  string
-	Roles []*AWSRole
+	Name          string
+	AccountNumber string
+	AccountAlias  string
+	Roles         []*AWSRole
 }
 
 // ParseAWSAccounts extract the aws accounts from the saml assertion
@@ -45,6 +54,12 @@ func ExtractAWSAccounts(data []byte) ([]*AWSAccount, error) {
 	doc.Find("fieldset > div.saml-account").Each(func(i int, s *goquery.Selection) {
 		account := new(AWSAccount)
 		account.Name = s.Find("div.saml-account-name").Text()
+		if m := accountNameRe.FindStringSubmatch(account.Name); m != nil {
+			account.AccountAlias = m[1]
+			account.AccountNumber = m[2]
+		} else if m := accountNumberRe.FindStringSubmatch(account.Name); m != nil {
+			account.AccountNumber = m[1]
+		}
 		s.Find("label").Each(func(i int, s *goquery.Selection) {
 			role := new(AWSRole)
 			role.Name = s.Text()

--- a/aws_account_test.go
+++ b/aws_account_test.go
@@ -17,6 +17,8 @@ func TestExtractAWSAccounts(t *testing.T) {
 
 	account := accounts[0]
 	assert.Equal(t, account.Name, "Account: account-alias (000000000001)")
+	assert.Equal(t, account.AccountNumber, "000000000001")
+	assert.Equal(t, account.AccountAlias, "account-alias")
 
 	assert.Len(t, account.Roles, 2)
 	role := account.Roles[0]
@@ -28,6 +30,8 @@ func TestExtractAWSAccounts(t *testing.T) {
 
 	account = accounts[1]
 	assert.Equal(t, account.Name, "Account: 000000000002")
+	assert.Equal(t, account.AccountNumber, "000000000002")
+	assert.Equal(t, account.AccountAlias, "")
 
 	assert.Len(t, account.Roles, 1)
 	role = account.Roles[0]

--- a/cmd/saml2aws/commands/list_roles.go
+++ b/cmd/saml2aws/commands/list_roles.go
@@ -140,6 +140,15 @@ func listRoles(awsRoles []*saml2aws.AWSRole, samlAssertion string, loginFlags *f
 	saml2aws.AssignPrincipals(awsRoles, awsAccounts)
 
 	if loginFlags.JSON {
+		output, err := json.Marshal(awsAccounts)
+		if err != nil {
+			return errors.Wrap(err, "error marshalling accounts to JSON")
+		}
+		fmt.Println(string(output))
+		return nil
+	}
+
+	if loginFlags.JSONPretty {
 		output, err := json.MarshalIndent(awsAccounts, "", "  ")
 		if err != nil {
 			return errors.Wrap(err, "error marshalling accounts to JSON")

--- a/cmd/saml2aws/commands/list_roles.go
+++ b/cmd/saml2aws/commands/list_roles.go
@@ -140,7 +140,7 @@ func listRoles(awsRoles []*saml2aws.AWSRole, samlAssertion string, loginFlags *f
 	saml2aws.AssignPrincipals(awsRoles, awsAccounts)
 
 	if loginFlags.JSON {
-		output, err := json.Marshal(awsAccounts)
+		output, err := json.MarshalIndent(awsAccounts, "", "  ")
 		if err != nil {
 			return errors.Wrap(err, "error marshalling accounts to JSON")
 		}

--- a/cmd/saml2aws/commands/list_roles.go
+++ b/cmd/saml2aws/commands/list_roles.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	b64 "encoding/base64"
+	"encoding/json"
 	"fmt"
 	"log"
 	"os"
@@ -137,6 +138,15 @@ func listRoles(awsRoles []*saml2aws.AWSRole, samlAssertion string, loginFlags *f
 	}
 
 	saml2aws.AssignPrincipals(awsRoles, awsAccounts)
+
+	if loginFlags.JSON {
+		output, err := json.Marshal(awsAccounts)
+		if err != nil {
+			return errors.Wrap(err, "error marshalling accounts to JSON")
+		}
+		fmt.Println(string(output))
+		return nil
+	}
 
 	log.Println("")
 	for _, account := range awsAccounts {

--- a/cmd/saml2aws/commands/list_roles_test.go
+++ b/cmd/saml2aws/commands/list_roles_test.go
@@ -1,0 +1,136 @@
+package commands
+
+import (
+	b64 "encoding/base64"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/h2non/gock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	saml2aws "github.com/versent/saml2aws/v2"
+	"github.com/versent/saml2aws/v2/pkg/flags"
+)
+
+// captureStdout replaces os.Stdout with a pipe for the duration of fn, then
+// returns everything that was written to it.
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	r, w, err := os.Pipe()
+	require.NoError(t, err)
+
+	old := os.Stdout
+	os.Stdout = w
+
+	fn()
+
+	w.Close()
+	os.Stdout = old
+
+	var sb strings.Builder
+	_, err = io.Copy(&sb, r)
+	require.NoError(t, err)
+	return sb.String()
+}
+
+// samlAssertionFixture returns the base64-encoded contents of testdata/assertion.xml.
+// The XML has Destination="https://signin.aws.amazon.com/saml".
+func samlAssertionFixture(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("../../../testdata/assertion.xml")
+	require.NoError(t, err)
+	return b64.StdEncoding.EncodeToString(data)
+}
+
+// awsRolesForSAMLHTML returns a set of AWSRole values whose RoleARNs match
+// the roles embedded in testdata/saml.html so that AssignPrincipals can link
+// them to the accounts returned by the mocked AWS sign-in page.
+func awsRolesForSAMLHTML() []*saml2aws.AWSRole {
+	return []*saml2aws.AWSRole{
+		{
+			RoleARN:      "arn:aws:iam::000000000001:role/Development",
+			PrincipalARN: "arn:aws:iam::000000000001:saml-provider/test-idp",
+		},
+		{
+			RoleARN:      "arn:aws:iam::000000000001:role/Production",
+			PrincipalARN: "arn:aws:iam::000000000001:saml-provider/test-idp",
+		},
+		{
+			RoleARN:      "arn:aws:iam::000000000002:role/Production",
+			PrincipalARN: "arn:aws:iam::000000000002:saml-provider/test-idp",
+		},
+	}
+}
+
+// mockAWSSignIn registers a gock interceptor that responds to the POST that
+// ParseAWSAccounts sends to https://signin.aws.amazon.com/saml with the
+// contents of testdata/saml.html.
+func mockAWSSignIn(t *testing.T) {
+	t.Helper()
+	samlHTML, err := os.ReadFile("../../../testdata/saml.html")
+	require.NoError(t, err)
+
+	gock.New("https://signin.aws.amazon.com").
+		Post("/saml").
+		Reply(200).
+		BodyString(string(samlHTML))
+}
+
+func TestListRolesTextOutput(t *testing.T) {
+	defer gock.Off()
+	mockAWSSignIn(t)
+
+	samlAssertion := samlAssertionFixture(t)
+	awsRoles := awsRolesForSAMLHTML()
+	loginFlags := &flags.LoginExecFlags{
+		CommonFlags: &flags.CommonFlags{},
+		JSON:        false,
+	}
+
+	output := captureStdout(t, func() {
+		err := listRoles(awsRoles, samlAssertion, loginFlags)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, output, "Account: account-alias (000000000001)")
+	assert.Contains(t, output, "arn:aws:iam::000000000001:role/Development")
+	assert.Contains(t, output, "arn:aws:iam::000000000001:role/Production")
+	assert.Contains(t, output, "Account: 000000000002")
+	assert.Contains(t, output, "arn:aws:iam::000000000002:role/Production")
+}
+
+func TestListRolesJSONOutput(t *testing.T) {
+	defer gock.Off()
+	mockAWSSignIn(t)
+
+	samlAssertion := samlAssertionFixture(t)
+	awsRoles := awsRolesForSAMLHTML()
+	loginFlags := &flags.LoginExecFlags{
+		CommonFlags: &flags.CommonFlags{},
+		JSON:        true,
+	}
+
+	output := captureStdout(t, func() {
+		err := listRoles(awsRoles, samlAssertion, loginFlags)
+		assert.NoError(t, err)
+	})
+
+	assert.Contains(t, output, `"Name":"Account: account-alias (000000000001)"`)
+	assert.Contains(t, output, `"RoleARN":"arn:aws:iam::000000000001:role/Development"`)
+	assert.Contains(t, output, `"RoleARN":"arn:aws:iam::000000000001:role/Production"`)
+	assert.Contains(t, output, `"Name":"Account: 000000000002"`)
+	assert.Contains(t, output, `"RoleARN":"arn:aws:iam::000000000002:role/Production"`)
+	assert.Contains(t, output, `"PrincipalARN":"arn:aws:iam::000000000001:saml-provider/test-idp"`)
+}
+
+func TestListRolesReturnsErrorWhenNoRoles(t *testing.T) {
+	loginFlags := &flags.LoginExecFlags{
+		CommonFlags: &flags.CommonFlags{},
+	}
+
+	err := listRoles([]*saml2aws.AWSRole{}, "", loginFlags)
+
+	assert.ErrorContains(t, err, "no roles available")
+}

--- a/cmd/saml2aws/commands/list_roles_test.go
+++ b/cmd/saml2aws/commands/list_roles_test.go
@@ -2,6 +2,7 @@ package commands
 
 import (
 	b64 "encoding/base64"
+	"encoding/json"
 	"io"
 	"os"
 	"strings"
@@ -117,12 +118,29 @@ func TestListRolesJSONOutput(t *testing.T) {
 		assert.NoError(t, err)
 	})
 
-	assert.Contains(t, output, `"Name":"Account: account-alias (000000000001)"`)
-	assert.Contains(t, output, `"RoleARN":"arn:aws:iam::000000000001:role/Development"`)
-	assert.Contains(t, output, `"RoleARN":"arn:aws:iam::000000000001:role/Production"`)
-	assert.Contains(t, output, `"Name":"Account: 000000000002"`)
-	assert.Contains(t, output, `"RoleARN":"arn:aws:iam::000000000002:role/Production"`)
-	assert.Contains(t, output, `"PrincipalARN":"arn:aws:iam::000000000001:saml-provider/test-idp"`)
+	// Verify the output is valid JSON and has the expected structure.
+	var accounts []struct {
+		Name  string `json:"Name"`
+		Roles []struct {
+			RoleARN      string `json:"RoleARN"`
+			PrincipalARN string `json:"PrincipalARN"`
+			Name         string `json:"Name"`
+		} `json:"Roles"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &accounts))
+
+	require.Len(t, accounts, 2)
+
+	assert.Equal(t, "Account: account-alias (000000000001)", accounts[0].Name)
+	require.Len(t, accounts[0].Roles, 2)
+	assert.Equal(t, "arn:aws:iam::000000000001:role/Development", accounts[0].Roles[0].RoleARN)
+	assert.Equal(t, "arn:aws:iam::000000000001:saml-provider/test-idp", accounts[0].Roles[0].PrincipalARN)
+	assert.Equal(t, "arn:aws:iam::000000000001:role/Production", accounts[0].Roles[1].RoleARN)
+
+	assert.Equal(t, "Account: 000000000002", accounts[1].Name)
+	require.Len(t, accounts[1].Roles, 1)
+	assert.Equal(t, "arn:aws:iam::000000000002:role/Production", accounts[1].Roles[0].RoleARN)
+	assert.Equal(t, "arn:aws:iam::000000000002:saml-provider/test-idp", accounts[1].Roles[0].PrincipalARN)
 }
 
 func TestListRolesReturnsErrorWhenNoRoles(t *testing.T) {

--- a/cmd/saml2aws/commands/list_roles_test.go
+++ b/cmd/saml2aws/commands/list_roles_test.go
@@ -120,8 +120,10 @@ func TestListRolesJSONOutput(t *testing.T) {
 
 	// Verify the output is valid JSON and has the expected structure.
 	var accounts []struct {
-		Name  string `json:"Name"`
-		Roles []struct {
+		Name          string `json:"Name"`
+		AccountNumber string `json:"AccountNumber"`
+		AccountAlias  string `json:"AccountAlias"`
+		Roles         []struct {
 			RoleARN      string `json:"RoleARN"`
 			PrincipalARN string `json:"PrincipalARN"`
 			Name         string `json:"Name"`
@@ -136,12 +138,16 @@ func TestListRolesJSONOutput(t *testing.T) {
 	require.Len(t, accounts, 2)
 
 	assert.Equal(t, "Account: account-alias (000000000001)", accounts[0].Name)
+	assert.Equal(t, "000000000001", accounts[0].AccountNumber)
+	assert.Equal(t, "account-alias", accounts[0].AccountAlias)
 	require.Len(t, accounts[0].Roles, 2)
 	assert.Equal(t, "arn:aws:iam::000000000001:role/Development", accounts[0].Roles[0].RoleARN)
 	assert.Equal(t, "arn:aws:iam::000000000001:saml-provider/test-idp", accounts[0].Roles[0].PrincipalARN)
 	assert.Equal(t, "arn:aws:iam::000000000001:role/Production", accounts[0].Roles[1].RoleARN)
 
 	assert.Equal(t, "Account: 000000000002", accounts[1].Name)
+	assert.Equal(t, "000000000002", accounts[1].AccountNumber)
+	assert.Equal(t, "", accounts[1].AccountAlias)
 	require.Len(t, accounts[1].Roles, 1)
 	assert.Equal(t, "arn:aws:iam::000000000002:role/Production", accounts[1].Roles[0].RoleARN)
 	assert.Equal(t, "arn:aws:iam::000000000002:saml-provider/test-idp", accounts[1].Roles[0].PrincipalARN)
@@ -165,8 +171,10 @@ func TestListRolesJSONPrettyOutput(t *testing.T) {
 
 	// Verify the output is valid JSON and has the expected structure.
 	var accounts []struct {
-		Name  string `json:"Name"`
-		Roles []struct {
+		Name          string `json:"Name"`
+		AccountNumber string `json:"AccountNumber"`
+		AccountAlias  string `json:"AccountAlias"`
+		Roles         []struct {
 			RoleARN      string `json:"RoleARN"`
 			PrincipalARN string `json:"PrincipalARN"`
 			Name         string `json:"Name"`
@@ -182,12 +190,16 @@ func TestListRolesJSONPrettyOutput(t *testing.T) {
 	require.Len(t, accounts, 2)
 
 	assert.Equal(t, "Account: account-alias (000000000001)", accounts[0].Name)
+	assert.Equal(t, "000000000001", accounts[0].AccountNumber)
+	assert.Equal(t, "account-alias", accounts[0].AccountAlias)
 	require.Len(t, accounts[0].Roles, 2)
 	assert.Equal(t, "arn:aws:iam::000000000001:role/Development", accounts[0].Roles[0].RoleARN)
 	assert.Equal(t, "arn:aws:iam::000000000001:saml-provider/test-idp", accounts[0].Roles[0].PrincipalARN)
 	assert.Equal(t, "arn:aws:iam::000000000001:role/Production", accounts[0].Roles[1].RoleARN)
 
 	assert.Equal(t, "Account: 000000000002", accounts[1].Name)
+	assert.Equal(t, "000000000002", accounts[1].AccountNumber)
+	assert.Equal(t, "", accounts[1].AccountAlias)
 	require.Len(t, accounts[1].Roles, 1)
 	assert.Equal(t, "arn:aws:iam::000000000002:role/Production", accounts[1].Roles[0].RoleARN)
 	assert.Equal(t, "arn:aws:iam::000000000002:saml-provider/test-idp", accounts[1].Roles[0].PrincipalARN)

--- a/cmd/saml2aws/commands/list_roles_test.go
+++ b/cmd/saml2aws/commands/list_roles_test.go
@@ -127,7 +127,57 @@ func TestListRolesJSONOutput(t *testing.T) {
 			Name         string `json:"Name"`
 		} `json:"Roles"`
 	}
-	require.NoError(t, json.Unmarshal([]byte(strings.TrimSpace(output)), &accounts))
+	trimmed := strings.TrimSpace(output)
+	require.NoError(t, json.Unmarshal([]byte(trimmed), &accounts))
+
+	// Compact JSON must be a single line (no embedded newlines).
+	assert.NotContains(t, trimmed, "\n")
+
+	require.Len(t, accounts, 2)
+
+	assert.Equal(t, "Account: account-alias (000000000001)", accounts[0].Name)
+	require.Len(t, accounts[0].Roles, 2)
+	assert.Equal(t, "arn:aws:iam::000000000001:role/Development", accounts[0].Roles[0].RoleARN)
+	assert.Equal(t, "arn:aws:iam::000000000001:saml-provider/test-idp", accounts[0].Roles[0].PrincipalARN)
+	assert.Equal(t, "arn:aws:iam::000000000001:role/Production", accounts[0].Roles[1].RoleARN)
+
+	assert.Equal(t, "Account: 000000000002", accounts[1].Name)
+	require.Len(t, accounts[1].Roles, 1)
+	assert.Equal(t, "arn:aws:iam::000000000002:role/Production", accounts[1].Roles[0].RoleARN)
+	assert.Equal(t, "arn:aws:iam::000000000002:saml-provider/test-idp", accounts[1].Roles[0].PrincipalARN)
+}
+
+func TestListRolesJSONPrettyOutput(t *testing.T) {
+	defer gock.Off()
+	mockAWSSignIn(t)
+
+	samlAssertion := samlAssertionFixture(t)
+	awsRoles := awsRolesForSAMLHTML()
+	loginFlags := &flags.LoginExecFlags{
+		CommonFlags: &flags.CommonFlags{},
+		JSONPretty:  true,
+	}
+
+	output := captureStdout(t, func() {
+		err := listRoles(awsRoles, samlAssertion, loginFlags)
+		assert.NoError(t, err)
+	})
+
+	// Verify the output is valid JSON and has the expected structure.
+	var accounts []struct {
+		Name  string `json:"Name"`
+		Roles []struct {
+			RoleARN      string `json:"RoleARN"`
+			PrincipalARN string `json:"PrincipalARN"`
+			Name         string `json:"Name"`
+		} `json:"Roles"`
+	}
+	trimmed := strings.TrimSpace(output)
+	require.NoError(t, json.Unmarshal([]byte(trimmed), &accounts))
+
+	// Pretty-printed JSON must contain newlines and indentation.
+	assert.Contains(t, trimmed, "\n")
+	assert.Contains(t, trimmed, "  ")
 
 	require.Len(t, accounts, 2)
 

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -154,6 +154,7 @@ func main() {
 	cmdListRoles.Flag("cache-file", "The location of the SAML cache file (env: SAML2AWS_SAML_CACHE_FILE)").Envar("SAML2AWS_SAML_CACHE_FILE").StringVar(&commonFlags.SAMLCacheFile)
 	listRolesFlags := new(flags.LoginExecFlags)
 	listRolesFlags.CommonFlags = commonFlags
+	cmdListRoles.Flag("json", "Output roles in JSON format.").BoolVar(&listRolesFlags.JSON)
 
 	// `script` command and settings
 	cmdScript := app.Command("script", "Emit a script that will export environment variables.")

--- a/cmd/saml2aws/main.go
+++ b/cmd/saml2aws/main.go
@@ -154,7 +154,8 @@ func main() {
 	cmdListRoles.Flag("cache-file", "The location of the SAML cache file (env: SAML2AWS_SAML_CACHE_FILE)").Envar("SAML2AWS_SAML_CACHE_FILE").StringVar(&commonFlags.SAMLCacheFile)
 	listRolesFlags := new(flags.LoginExecFlags)
 	listRolesFlags.CommonFlags = commonFlags
-	cmdListRoles.Flag("json", "Output roles in JSON format.").BoolVar(&listRolesFlags.JSON)
+	cmdListRoles.Flag("json", "Output roles in JSON format (compact).").BoolVar(&listRolesFlags.JSON)
+	cmdListRoles.Flag("json-pretty", "Output roles in JSON format (pretty-printed).").BoolVar(&listRolesFlags.JSONPretty)
 
 	// `script` command and settings
 	cmdScript := app.Command("script", "Emit a script that will export environment variables.")

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -51,6 +51,7 @@ type LoginExecFlags struct {
 	ExecProfile       string
 	CredentialProcess bool
 	TryNoPrompt       bool
+	JSON              bool
 }
 
 type ConsoleFlags struct {

--- a/pkg/flags/flags.go
+++ b/pkg/flags/flags.go
@@ -52,6 +52,7 @@ type LoginExecFlags struct {
 	CredentialProcess bool
 	TryNoPrompt       bool
 	JSON              bool
+	JSONPretty        bool
 }
 
 type ConsoleFlags struct {


### PR DESCRIPTION
This pull request enhances the AWS roles listing functionality by adding support for JSON output (both compact and pretty-printed), extracting and exposing AWS account numbers and aliases, and introducing comprehensive tests for these changes. The most important changes are summarized below.

### Output format enhancements

* Added `--json` and `--json-pretty` flags to the `list-roles` command, allowing users to output AWS account and role information in compact or pretty-printed JSON formats. [[1]](diffhunk://#diff-700f078cb6e14d20af7c09e73a1507604a85cfb66d6c54db727f45dc21a13d2aR157-R158) [[2]](diffhunk://#diff-86a6b54df1345b10b1d2385b6a236500d34a82625045de56a08d4f711b505b88R54-R55) [[3]](diffhunk://#diff-5fef00063c6ae2d8728bbe133089923b7a990513ada22232a2a817a8fddf4285R5) [[4]](diffhunk://#diff-5fef00063c6ae2d8728bbe133089923b7a990513ada22232a2a817a8fddf4285R142-R159)

### AWS account parsing improvements

* Updated the `AWSAccount` struct to include `AccountNumber` and `AccountAlias` fields, and enhanced parsing logic to extract these values from account names using regular expressions. [[1]](diffhunk://#diff-8255aede52e5ac06fe83b82df018a4a4261cf060f880740269395e0dc84d053cR9-R25) [[2]](diffhunk://#diff-8255aede52e5ac06fe83b82df018a4a4261cf060f880740269395e0dc84d053cR57-R62)

### Testing

* Added a new test suite for the `list-roles` command, covering text output, compact JSON, pretty-printed JSON, and error handling when no roles are present.
* Updated existing AWS account extraction tests to validate the new `AccountNumber` and `AccountAlias` fields. [[1]](diffhunk://#diff-9cab9566bd2ffff10e687907b495e59766d81a0adc09a132e0bc00e52234f904R20-R21) [[2]](diffhunk://#diff-9cab9566bd2ffff10e687907b495e59766d81a0adc09a132e0bc00e52234f904R33-R34)