### PR TITLE
fix(aad): Continue past optional MFA setup

### DIFF
--- a/pkg/provider/aad/aad.go
+++ b/pkg/provider/aad/aad.go
@@ -37,6 +37,7 @@ type ConvergedResponse struct {
 	URLGetCredentialType    string             `json:"urlGetCredentialType"`
 	ArrUserProofs           []userProof        `json:"arrUserProofs"`
 	URLSkipMfaRegistration  string             `json:"urlSkipMfaRegistration"`
+	URLPostRedirect         string             `json:"urlPostRedirect"`
 	OPerAuthPollingInterval map[string]float64 `json:"oPerAuthPollingInterval"`
 	URLBeginAuth            string             `json:"urlBeginAuth"`
 	URLEndAuth              string             `json:"urlEndAuth"`
@@ -47,6 +48,7 @@ type ConvergedResponse struct {
 	SFT                     string             `json:"sFT"`
 	SFTName                 string             `json:"sFTName"`
 	SCtx                    string             `json:"sCtx"`
+	ProofUpAuthState        string             `json:"sProofUpAuthState"`
 	Hpgact                  int                `json:"hpgact"`
 	Hpgid                   int                `json:"hpgid"`
 	Pgid                    string             `json:"pgid"`
@@ -656,21 +658,61 @@ func (ac *Client) processConvergedProofUpRedirect(res *http.Response, srcBodyStr
 		return res, errors.Wrap(err, "skip MFA response unmarshal error")
 	}
 
+	if convergedResponse.URLSkipMfaRegistration != "" {
+		if canProcessProofUpSkip(convergedResponse) {
+			formValues := url.Values{}
+			formValues.Set("type", "22")
+			formValues.Set("request", convergedResponse.ProofUpAuthState)
+			formValues.Set(convergedResponse.SFTName, convergedResponse.SFT)
+			formValues.Set("ctx", convergedResponse.ProofUpAuthState)
+			formValues.Set("canary", convergedResponse.Canary)
+			formValues.Set("hpgrequestid", convergedResponse.CorrelationID)
+
+			req, err := http.NewRequest("POST", ac.fullUrl(res, convergedResponse.URLPostRedirect), strings.NewReader(formValues.Encode()))
+			if err != nil {
+				return res, errors.Wrap(err, "error building skip MFA registration request")
+			}
+			req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+			res, err = ac.client.Do(req)
+			if err != nil {
+				return res, errors.Wrap(err, "error processing skip MFA registration request")
+			}
+			return res, nil
+		}
+
+		res, err = ac.client.Get(convergedResponse.URLSkipMfaRegistration)
+		if err != nil {
+			return res, errors.Wrap(err, "error processing skip MFA request")
+		}
+		return res, nil
+	}
+
 	// 50058: user is not signed in (yet)
 	if convergedResponse.SErrorCode != "" && convergedResponse.SErrorCode != "50058" {
 		return res, fmt.Errorf("login error %s", convergedResponse.SErrorCode)
 	}
 
-	if convergedResponse.URLSkipMfaRegistration == "" {
-		return res, errors.Wrap(err, "skip MFA not possible")
+	return res, errors.New("skip MFA not possible")
+}
+
+func canProcessProofUpSkip(convergedResponse *ConvergedResponse) bool {
+	if convergedResponse == nil ||
+		convergedResponse.URLPostRedirect == "" ||
+		convergedResponse.ProofUpAuthState == "" ||
+		convergedResponse.SFTName == "" ||
+		convergedResponse.SFT == "" ||
+		convergedResponse.Canary == "" ||
+		convergedResponse.CorrelationID == "" {
+		return false
 	}
 
-	res, err = ac.client.Get(convergedResponse.URLSkipMfaRegistration)
-	if err != nil {
-		return res, errors.Wrap(err, "error processing skip MFA request")
+	switch convergedResponse.SFTName {
+	case "type", "request", "ctx", "canary", "hpgrequestid":
+		return false
+	default:
+		return true
 	}
-
-	return res, nil
 }
 
 func (ac *Client) unmarshalEmbeddedJson(resBodyStr string, v any) error {

--- a/pkg/provider/aad/aad_test.go
+++ b/pkg/provider/aad/aad_test.go
@@ -13,6 +13,7 @@ import (
 	mrand "math/rand"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"os"
 	"strconv"
 	"sync"
@@ -243,6 +244,10 @@ func Test_Authenticate(t *testing.T) {
 					UrlSkipMfaRegistration: "/skipMfaRegistration",
 				})
 			case "/skipMfaRegistration":
+				if r.Method != http.MethodGet {
+					http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+					return
+				}
 				writeFixtureBytes(t, w, r, "KmsiInterrupt.html", FixtureData{
 					UrlPost: "/hForm",
 				})
@@ -266,6 +271,68 @@ func Test_Authenticate(t *testing.T) {
 		got, err := ac.Authenticate(loginDetails)
 		require.Nil(t, err)
 		require.NotEmpty(t, got)
+	})
+	t.Run("Default login with snoozable MFA registration", func(t *testing.T) {
+		fixtureData := genFixtureData()
+		skipRequests := make(chan url.Values, 1)
+		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			switch r.URL.Path {
+			case "/index", "/applications/redirecttofederatedapplication.aspx":
+				writeFixtureBytes(t, w, r, "ConvergedSignIn.html", FixtureData{
+					UrlPost:              "/defaultLogin",
+					UrlGetCredentialType: "/getCredentialType",
+				})
+			case "/getCredentialType":
+				writeFixtureBytes(t, w, r, "GetCredentialType_default.json", FixtureData{})
+			case "/defaultLogin":
+				writeFixtureBytes(t, w, r, "ConvergedProofUpRedirect.html", FixtureData{
+					SErrorCode:             "50203",
+					UrlProcessAuth:         "/skipMfaRegistration",
+					UrlSkipMfaRegistration: "/legacySkipMfaRegistration",
+				})
+			case "/skipMfaRegistration":
+				if r.Method != http.MethodPost {
+					http.Error(w, http.StatusText(http.StatusMethodNotAllowed), http.StatusMethodNotAllowed)
+					return
+				}
+				if err := r.ParseForm(); err != nil {
+					http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+					return
+				}
+				skipRequests <- r.PostForm
+				writeFixtureBytes(t, w, r, "KmsiInterrupt.html", FixtureData{
+					UrlPost: "/hForm",
+				})
+			case "/legacySkipMfaRegistration":
+				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			case "/hForm":
+				writeFixtureBytes(t, w, r, "HiddenForm.html", FixtureData{
+					UrlHiddenForm: "/sRequest",
+				})
+			case "/sRequest":
+				writeFixtureBytes(t, w, r, "SAMLRequest.html", FixtureData{
+					UrlSamlRequest: "/sResponse?SAMLRequest=ExampleValue",
+				})
+			case "/sResponse":
+				writeFixtureBytes(t, w, r, "SAMLResponse.html", FixtureData{})
+			default:
+				http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+			}
+		}))
+		defer ts.Close()
+
+		ac, loginDetails := setupTestClient(t, ts)
+		got, err := ac.Authenticate(loginDetails)
+		require.Nil(t, err)
+		require.NotEmpty(t, got)
+		require.Equal(t, url.Values{
+			"type":         []string{"22"},
+			"request":      []string{fixtureData.Ctx},
+			"flowToken":    []string{fixtureData.SFT},
+			"ctx":          []string{fixtureData.Ctx},
+			"canary":       []string{fixtureData.Canary + "=6:1"},
+			"hpgrequestid": []string{fixtureData.ClientRequestId},
+		}, <-skipRequests)
 	})
 	t.Run("Default login with KMSI and MFA", func(t *testing.T) {
 		ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -539,6 +606,46 @@ func Test_Authenticate(t *testing.T) {
 		require.Nil(t, err)
 		require.NotEmpty(t, got)
 	})
+}
+
+func Test_canProcessProofUpSkip(t *testing.T) {
+	newResponse := func() ConvergedResponse {
+		return ConvergedResponse{
+			URLPostRedirect:  "https://login.microsoftonline.com/common/SAS/ProcessAuth",
+			ProofUpAuthState: "proof-up-state",
+			SFTName:          "flowToken",
+			SFT:              "flow-token",
+			Canary:           "canary",
+			CorrelationID:    "correlation-id",
+		}
+	}
+
+	complete := newResponse()
+	require.True(t, canProcessProofUpSkip(&complete))
+
+	missingValues := map[string]func(*ConvergedResponse){
+		"post redirect URL": func(response *ConvergedResponse) { response.URLPostRedirect = "" },
+		"proof-up state":    func(response *ConvergedResponse) { response.ProofUpAuthState = "" },
+		"flow token name":   func(response *ConvergedResponse) { response.SFTName = "" },
+		"flow token":        func(response *ConvergedResponse) { response.SFT = "" },
+		"canary":            func(response *ConvergedResponse) { response.Canary = "" },
+		"correlation ID":    func(response *ConvergedResponse) { response.CorrelationID = "" },
+	}
+	for name, removeValue := range missingValues {
+		t.Run("missing "+name, func(t *testing.T) {
+			response := newResponse()
+			removeValue(&response)
+			require.False(t, canProcessProofUpSkip(&response))
+		})
+	}
+
+	for _, reservedName := range []string{"type", "request", "ctx", "canary", "hpgrequestid"} {
+		t.Run("reserved "+reservedName, func(t *testing.T) {
+			response := newResponse()
+			response.SFTName = reservedName
+			require.False(t, canProcessProofUpSkip(&response))
+		})
+	}
 }
 
 func setupTestClient(t *testing.T, ts *httptest.Server) (Client, *creds.LoginDetails) {


### PR DESCRIPTION
## Summary

Microsoft can occasionally ask users to set up an additional sign-in method, with an option to choose **Not now**. saml2aws currently stops instead of completing that offered path.

This change sends Microsoft the continuation details from that page, allowing the AWS login to finish automatically. Older versions of the prompt remain supported. If Microsoft requires registration and does not offer a skip option, saml2aws still stops as before.

## Why this matters

Affected users can be blocked once a day by a setup reminder even though their existing sign-in method is valid. Automating Microsoft's offered **Not now** action restores command-line workflows without weakening required registration policies.

The flow was validated against a live `50203` registration prompt: it continued through the normal sign-in pages and returned AWS credentials.

## Validation

- Added coverage for the current registration continuation request
- Preserved compatibility with the older continuation path
- Confirmed mandatory `502031` registration remains enforced
- Full tests, build, static checks, and race checks pass

Resolves #1540.